### PR TITLE
feat: reflect failed task status to GitHub Issues via label

### DIFF
--- a/src/cli/lib/github-model.ts
+++ b/src/cli/lib/github-model.ts
@@ -53,7 +53,7 @@ export interface SyncResult {
 
 export interface StatusSyncResult {
   updated: number;
-  issues: { taskId: string; issueNumber: number; status: "open" | "closed" }[];
+  issues: { taskId: string; issueNumber: number; status: "open" | "closed"; labels: string[] }[];
   errors: string[];
 }
 


### PR DESCRIPTION
## Summary
- `labelTaskIssue()` 追加: `gh issue edit --add-label` で任意ラベルを付与
- `failTask()` 後に "failed" ラベルをGitHub Issueに付与（closeしない = 再実行可能）
- `StatusSyncResult` に `labels` フィールド追加
- `enrichTasksFromGitHub()` で open + "failed" ラベル → failed ステータスにマッピング

## 設計判断
- failed 時は Issue を **close しない**（再実行の余地を残す）
- ラベルベースで状態管理（GitHub Projects の Status フィールドとも整合）
- `ensureLabels()` で "failed" ラベルが存在しなければ自動作成

## Test plan
- [x] `labelTaskIssue` 正常系/エラー系 (4テスト)
- [x] `syncStatusFromGitHub` ラベル伝播テスト
- [x] `runTask` fail 時の GitHub label 付与テスト
- [x] 全978テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)