### PR TITLE
fix: unify task ID generation to single source in plan-model.ts

### DIFF
--- a/src/cli/lib/github-engine.test.ts
+++ b/src/cli/lib/github-engine.test.ts
@@ -31,7 +31,7 @@ import {
   saveSyncState,
   loadSyncState,
 } from "./github-model.js";
-import type { PlanState, Feature, Wave } from "./plan-model.js";
+import { type PlanState, type Feature, type Wave, decomposeFeature } from "./plan-model.js";
 
 // ─────────────────────────────────────────────
 // Test helpers
@@ -78,11 +78,14 @@ function createTestPlan(): PlanState {
     },
   ];
 
+  const tasks = features.flatMap((f) => decomposeFeature(f));
+
   return {
     status: "generated",
     generatedAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     waves,
+    tasks,
     circularDependencies: [],
   };
 }
@@ -266,6 +269,15 @@ describe("syncPlanToGitHub", () => {
       return "";
     });
 
+    const feature: Feature = {
+      id: "FEAT-001",
+      name: "Test",
+      priority: "P0",
+      size: "S",
+      type: "common",
+      dependencies: [],
+      dependencyCount: 0,
+    };
     const plan: PlanState = {
       status: "generated",
       generatedAt: "",
@@ -276,19 +288,10 @@ describe("syncPlanToGitHub", () => {
           phase: "common",
           layer: 1,
           title: "Wave 1",
-          features: [
-            {
-              id: "FEAT-001",
-              name: "Test",
-              priority: "P0",
-              size: "S",
-              type: "common",
-              dependencies: [],
-              dependencyCount: 0,
-            },
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 
@@ -311,6 +314,15 @@ describe("syncPlanToGitHub", () => {
     });
 
     const messages: string[] = [];
+    const feature: Feature = {
+      id: "F-001",
+      name: "X",
+      priority: "P0",
+      size: "S",
+      type: "common",
+      dependencies: [],
+      dependencyCount: 0,
+    };
     const plan: PlanState = {
       status: "generated",
       generatedAt: "",
@@ -320,19 +332,10 @@ describe("syncPlanToGitHub", () => {
           number: 1,
           phase: "common",
           title: "Wave 1",
-          features: [
-            {
-              id: "F-001",
-              name: "X",
-              priority: "P0",
-              size: "S",
-              type: "common",
-              dependencies: [],
-              dependencyCount: 0,
-            },
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 
@@ -358,6 +361,15 @@ describe("syncPlanToGitHub", () => {
       return "";
     });
 
+    const feature: Feature = {
+      id: "FEAT-100",
+      name: "User Login",
+      priority: "P0",
+      size: "S",
+      type: "common",
+      dependencies: [],
+      dependencyCount: 0,
+    };
     const plan: PlanState = {
       status: "generated",
       generatedAt: "",
@@ -367,19 +379,10 @@ describe("syncPlanToGitHub", () => {
           number: 1,
           phase: "common",
           title: "W1",
-          features: [
-            {
-              id: "FEAT-100",
-              name: "User Login",
-              priority: "P0",
-              size: "S",
-              type: "common",
-              dependencies: [],
-              dependencyCount: 0,
-            },
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 
@@ -410,6 +413,15 @@ describe("syncPlanToGitHub", () => {
       return "";
     });
 
+    const feature: Feature = {
+      id: "FEAT-050",
+      name: "Payment Processing",
+      priority: "P0",
+      size: "M",
+      type: "proprietary",
+      dependencies: [],
+      dependencyCount: 0,
+    };
     const plan: PlanState = {
       status: "generated",
       generatedAt: "",
@@ -419,19 +431,10 @@ describe("syncPlanToGitHub", () => {
           number: 1,
           phase: "common",
           title: "W1",
-          features: [
-            {
-              id: "FEAT-050",
-              name: "Payment Processing",
-              priority: "P0",
-              size: "M",
-              type: "proprietary",
-              dependencies: [],
-              dependencyCount: 0,
-            },
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 
@@ -479,6 +482,15 @@ describe("syncPlanToGitHub", () => {
       return "";
     });
 
+    const feature: Feature = {
+      id: "FEAT-X",
+      name: "Test Feature",
+      priority: "P0",
+      size: "S",
+      type: "common",
+      dependencies: [],
+      dependencyCount: 0,
+    };
     const plan: PlanState = {
       status: "generated",
       generatedAt: "",
@@ -488,19 +500,10 @@ describe("syncPlanToGitHub", () => {
           number: 1,
           phase: "common",
           title: "W1",
-          features: [
-            {
-              id: "FEAT-X",
-              name: "Test Feature",
-              priority: "P0",
-              size: "S",
-              type: "common",
-              dependencies: [],
-              dependencyCount: 0,
-            },
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 

--- a/src/cli/lib/plan-engine.test.ts
+++ b/src/cli/lib/plan-engine.test.ts
@@ -9,7 +9,7 @@ import {
   calculateDependencyCounts,
   generatePlanMarkdown,
 } from "./plan-engine.js";
-import { type Feature, loadPlan } from "./plan-model.js";
+import { type Feature, decomposeFeature, loadPlan } from "./plan-model.js";
 
 function createMockIO(): PlanIO & { output: string[] } {
   const output: string[] = [];
@@ -364,6 +364,7 @@ describe("calculateDependencyCounts", () => {
 
 describe("generatePlanMarkdown", () => {
   it("generates markdown with wave tables", () => {
+    const feature = makeFeature({ id: "FEAT-001", name: "Login", priority: "P0", size: "M" });
     const plan = {
       status: "generated" as const,
       generatedAt: "2026-02-03T00:00:00Z",
@@ -373,11 +374,10 @@ describe("generatePlanMarkdown", () => {
           number: 1,
           phase: "individual" as const,
           title: "Wave 1: Independent Features",
-          features: [
-            makeFeature({ id: "FEAT-001", name: "Login", priority: "P0", size: "M" }),
-          ],
+          features: [feature],
         },
       ],
+      tasks: decomposeFeature(feature),
       circularDependencies: [],
     };
 

--- a/src/cli/lib/plan-engine.ts
+++ b/src/cli/lib/plan-engine.ts
@@ -367,8 +367,7 @@ export function generatePlanMarkdown(plan: PlanState): string {
     // Task decomposition per feature
     for (const feature of wave.features) {
       // Use pre-computed tasks from plan when available (profile-aware order)
-      const featureTasks = (plan.tasks ?? []).filter((t) => t.featureId === feature.id);
-      const tasks = featureTasks.length > 0 ? featureTasks : decomposeFeature(feature);
+      const tasks = (plan.tasks ?? []).filter((t) => t.featureId === feature.id);
       lines.push(`### ${feature.id}: ${feature.name}`);
       lines.push("");
       lines.push("| Task | Size | Blocked By | References |");


### PR DESCRIPTION
## Summary
- Remove independent `decomposeFeature()` calls from `github-engine.ts` and `run-engine.ts`
- Both now read task IDs from `plan.tasks` (Single Source of Truth) instead of regenerating them
- Fixes latent bug: `github-engine.ts` used default "normal" order mode, producing wrong task ordering for api/cli profiles (TDD mode)

## Changes
- **github-engine.ts**: Replace `decomposeFeature()` with `plan.tasks` filter, remove import
- **run-engine.ts**: Remove fallback path, unused `profileType` / `InitRunStateOptions`
- **plan-engine.ts**: Remove `decomposeFeature` fallback in `formatPlanReport()`
- **Tests**: All 992 tests pass; updated test helpers to provide `plan.tasks`

## Test plan
- [x] All existing tests pass (992/992)
- [x] New test: `initRunStateFromPlan` throws when `plan.tasks` is missing
- [x] TDD and normal order tests verify plan.tasks is used directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)