### PR TITLE
fix: store GitHub Issue bodies in sync state for deterministic reconstruction

### DIFF
--- a/src/cli/lib/github-model.ts
+++ b/src/cli/lib/github-model.ts
@@ -19,11 +19,15 @@ const execFileAsync = promisify(execFile);
 export interface TaskIssueMap {
   taskId: string;
   issueNumber: number;
+  /** Stored issue body for drift detection and reconstruction */
+  body?: string;
 }
 
 export interface FeatureIssueMap {
   featureId: string;
   parentIssueNumber: number;
+  /** Stored parent issue body for drift detection and reconstruction */
+  body?: string;
   taskIssues: TaskIssueMap[];
 }
 


### PR DESCRIPTION
## Summary
- Extract `generateFeatureIssueBody()` and `generateTaskIssueBody()` as pure, exported functions from `github-engine.ts`
- Store generated bodies in `github-sync.json` (`FeatureIssueMap.body` and `TaskIssueMap.body`) for drift detection and reconstruction
- Add tests verifying deterministic body generation from feature/task data

## Test plan
- [x] `generateFeatureIssueBody` produces deterministic output
- [x] `generateTaskIssueBody` produces deterministic output with SSOT reference, branch, dependencies, parent link
- [x] `syncPlanToGitHub` stores bodies in sync state
- [x] All 994 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)