### PR TITLE
feat: framework next / framework current コマンド分離 (#15)

### DIFF
--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -1,0 +1,141 @@
+/**
+ * framework next  - Show the next task to work on (by seq order)
+ * framework current - Show the currently in-progress task
+ *
+ * Design: docs/TASK-SEQUENCE-DESIGN.md
+ * Issue: #15
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { type Command } from "commander";
+import {
+  loadRunState,
+  getCurrentTask,
+  getNextTaskBySeq,
+} from "../lib/run-model.js";
+import { logger } from "../lib/logger.js";
+
+const AUDIT_LOG = ".framework/audit.log";
+
+function appendAuditLog(projectDir: string, entry: object): void {
+  const logPath = path.join(projectDir, AUDIT_LOG);
+  const dir = path.dirname(logPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(logPath, JSON.stringify(entry) + "\n", "utf-8");
+}
+
+export function registerNextCommand(program: Command): void {
+  // ── framework next ──────────────────────────────────────────────────────
+  program
+    .command("next")
+    .description("Show the next task to work on (ordered by seq)")
+    .option("--force", "Ignore in-progress tasks and return next todo anyway")
+    .option("--json", "Output as JSON")
+    .action(async (options: { force?: boolean; json?: boolean }) => {
+      const projectDir = process.cwd();
+      const state = loadRunState(projectDir);
+
+      if (!state) {
+        logger.error(
+          "No run state found. Run 'framework run' to initialize.",
+        );
+        process.exit(1);
+      }
+
+      // Check for in-progress tasks
+      const inProgress = state.tasks.filter(
+        (t) => t.status === "in_progress",
+      );
+
+      if (inProgress.length > 0 && !options.force) {
+        logger.warn("⚠️  作業中のタスクがあります。完了してから next を実行してください。");
+        logger.info("");
+        for (const t of inProgress) {
+          logger.info(`  in_progress: ${t.taskId}${t.seq ? ` [${t.seq}]` : ""} — ${t.name}`);
+        }
+        logger.info("");
+        logger.info("  強制的に次のタスクを取得するには: framework next --force");
+        process.exit(1);
+      }
+
+      if (inProgress.length > 0 && options.force) {
+        // Audit trail for --force usage
+        const skipped = inProgress.map((t) => t.taskId);
+        appendAuditLog(projectDir, {
+          timestamp: new Date().toISOString(),
+          command: "next --force",
+          skipped,
+        });
+        logger.warn(
+          `⚠️  --force: ${skipped.length} 件の in_progress タスクをスキップ (audit.log に記録済み)`,
+        );
+      }
+
+      const next = getNextTaskBySeq(state);
+
+      if (!next) {
+        logger.info("✅ 全タスク完了。次のタスクはありません。");
+        return;
+      }
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(next, null, 2) + "\n");
+        return;
+      }
+
+      logger.header("Next Task");
+      logger.info("");
+      logger.info(`  Task ID : ${next.taskId}`);
+      if (next.seq) logger.info(`  Seq     : ${next.seq}`);
+      logger.info(`  Feature : ${next.featureId}`);
+      logger.info(`  Kind    : ${next.taskKind}`);
+      logger.info(`  Name    : ${next.name}`);
+      logger.info(`  Status  : ${next.status}`);
+      logger.info("");
+      logger.info(`  To start: framework run ${next.taskId}`);
+      logger.info("");
+    });
+
+  // ── framework current ────────────────────────────────────────────────────
+  program
+    .command("current")
+    .description("Show the currently in-progress task")
+    .option("--json", "Output as JSON")
+    .action(async (options: { json?: boolean }) => {
+      const projectDir = process.cwd();
+      const state = loadRunState(projectDir);
+
+      if (!state) {
+        logger.error(
+          "No run state found. Run 'framework run' to initialize.",
+        );
+        process.exit(1);
+      }
+
+      const current = getCurrentTask(state);
+
+      if (!current) {
+        logger.info("作業中のタスクはありません。");
+        logger.info("  次のタスクを確認するには: framework next");
+        return;
+      }
+
+      if (options.json) {
+        process.stdout.write(JSON.stringify(current, null, 2) + "\n");
+        return;
+      }
+
+      logger.header("Current Task");
+      logger.info("");
+      logger.info(`  Task ID : ${current.taskId}`);
+      if (current.seq) logger.info(`  Seq     : ${current.seq}`);
+      logger.info(`  Feature : ${current.featureId}`);
+      logger.info(`  Kind    : ${current.taskKind}`);
+      logger.info(`  Name    : ${current.name}`);
+      logger.info(`  Status  : ${current.status}`);
+      if (current.startedAt) {
+        logger.info(`  Started : ${current.startedAt}`);
+      }
+      logger.info("");
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { registerDeployCommand } from "./commands/deploy.js";
 import { registerGateCommand } from "./commands/gate.js";
 import { registerFeedbackCommand } from "./commands/feedback.js";
 import { registerProjectsCommand } from "./commands/projects.js";
+import { registerNextCommand } from "./commands/next.js";
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,6 +51,7 @@ registerPlanCommand(program);
 registerGateCommand(program);
 registerAuditCommand(program);
 registerRunCommand(program);
+registerNextCommand(program);
 registerStatusCommand(program);
 
 // Project management

--- a/src/cli/lib/run-model.test.ts
+++ b/src/cli/lib/run-model.test.ts
@@ -239,3 +239,79 @@ describe("run-model", () => {
     });
   });
 });
+
+// ─────────────────────────────────────────────
+// getCurrentTask / getNextTaskBySeq
+// ─────────────────────────────────────────────
+
+import { getCurrentTask, getNextTaskBySeq } from "./run-model.js";
+
+function makeTaskWithSeq(
+  taskId: string,
+  status: TaskExecution["status"],
+  seq?: string,
+): TaskExecution {
+  return {
+    taskId,
+    featureId: "F1",
+    taskKind: "db",
+    name: taskId,
+    status,
+    blockedBy: [],
+    files: [],
+    seq,
+  };
+}
+
+describe("getCurrentTask", () => {
+  it("returns in_progress task", () => {
+    const state = createRunState();
+    state.tasks = [
+      makeTaskWithSeq("T1", "backlog", "1000100010"),
+      makeTaskWithSeq("T2", "in_progress", "1000100020"),
+    ];
+    expect(getCurrentTask(state)?.taskId).toBe("T2");
+  });
+
+  it("returns undefined when no in_progress task", () => {
+    const state = createRunState();
+    state.tasks = [makeTaskWithSeq("T1", "backlog", "1000100010")];
+    expect(getCurrentTask(state)).toBeUndefined();
+  });
+});
+
+describe("getNextTaskBySeq", () => {
+  it("returns backlog task with smallest seq", () => {
+    const state = createRunState();
+    state.tasks = [
+      makeTaskWithSeq("T3", "backlog", "1000300010"),
+      makeTaskWithSeq("T1", "backlog", "1000100010"),
+      makeTaskWithSeq("T2", "backlog", "1000200010"),
+    ];
+    expect(getNextTaskBySeq(state)?.taskId).toBe("T1");
+  });
+
+  it("skips done tasks", () => {
+    const state = createRunState();
+    state.tasks = [
+      makeTaskWithSeq("T1", "done", "1000100010"),
+      makeTaskWithSeq("T2", "backlog", "1000200010"),
+    ];
+    expect(getNextTaskBySeq(state)?.taskId).toBe("T2");
+  });
+
+  it("returns undefined when no backlog tasks", () => {
+    const state = createRunState();
+    state.tasks = [makeTaskWithSeq("T1", "done", "1000100010")];
+    expect(getNextTaskBySeq(state)).toBeUndefined();
+  });
+
+  it("falls back to insertion order when seq is absent", () => {
+    const state = createRunState();
+    state.tasks = [
+      makeTaskWithSeq("T1", "backlog", undefined),
+      makeTaskWithSeq("T2", "backlog", undefined),
+    ];
+    expect(getNextTaskBySeq(state)?.taskId).toBe("T1");
+  });
+});

--- a/src/cli/lib/run-model.ts
+++ b/src/cli/lib/run-model.ts
@@ -80,6 +80,11 @@ export interface TaskExecution {
   escalation?: Escalation;
   startedAt?: string;
   completedAt?: string;
+  /**
+   * Implementation sequence number (WWWFFFFTTT, 10-digit).
+   * Populated from plan.json Task.seq at run-state initialization.
+   */
+  seq?: string;
 }
 
 // ─────────────────────────────────────────────
@@ -122,6 +127,35 @@ export function getNextPendingTask(
   state: RunState,
 ): TaskExecution | undefined {
   return state.tasks.find((t) => t.status === "backlog");
+}
+
+/**
+ * Get the currently in-progress task (framework current).
+ */
+export function getCurrentTask(
+  state: RunState,
+): TaskExecution | undefined {
+  return state.tasks.find((t) => t.status === "in_progress");
+}
+
+/**
+ * Get the next todo task by seq order (framework next).
+ * Returns the backlog task with the smallest seq value.
+ * Falls back to insertion order if seq is not available.
+ */
+export function getNextTaskBySeq(
+  state: RunState,
+): TaskExecution | undefined {
+  const backlog = state.tasks.filter((t) => t.status === "backlog");
+  if (backlog.length === 0) return undefined;
+
+  // Sort by seq (lexicographic), fall back to original order if seq absent
+  return backlog.sort((a, b) => {
+    if (a.seq && b.seq) return a.seq.localeCompare(b.seq);
+    if (a.seq) return -1;
+    if (b.seq) return 1;
+    return 0;
+  })[0];
 }
 
 export function startTask(


### PR DESCRIPTION
## 参照SSOT
docs/TASK-SEQUENCE-DESIGN.md

## 概要
Issue #15 の実装。next/current を明確に分離し、seq 順で次タスクを返す。

## 変更内容
- `run-model.ts`: `seq` フィールド追加、`getCurrentTask()` / `getNextTaskBySeq()` 追加
- `commands/next.ts`: `framework next` / `framework current` コマンド（新規）
- `index.ts`: `registerNextCommand` を登録

## 仕様
- `framework current`: status=in_progress のタスクを返す
- `framework next`: 最小 seq の backlog タスクを返す。in_progress があれば警告
- `framework next --force`: in_progress を無視して次 todo を返す（audit.log 記録）
- `--json` オプションで JSON 出力

## テスト・証跡
- 全22テスト pass（既存16件 + 新規6件）
- TypeScript コンパイルエラーなし

## CI
ローカル vitest 全通過

Closes #15