### PR TITLE
feat: Final Audit GitHub Actions ワークフロー (#25)

### DIFF
--- a/.github/workflows/final-audit.yml
+++ b/.github/workflows/final-audit.yml
@@ -1,0 +1,290 @@
+name: Final Audit
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches-ignore: [main]
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  # ============================================================
+  # Guard: CI must have passed, PR must not have 'hold' label
+  # ============================================================
+  guard:
+    name: Guard — CI passed & no hold label
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      pr_number: ${{ steps.find_pr.outputs.pr_number }}
+      skip: ${{ steps.check_hold.outputs.skip }}
+    steps:
+      - name: Find associated PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$BRANCH" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for branch $BRANCH — skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check hold label
+        id: check_hold
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ steps.find_pr.outputs.pr_number }}"
+          if [ -z "$PR" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LABELS=$(gh pr view "$PR" \
+            --repo "${{ github.repository }}" \
+            --json labels \
+            --jq '.labels[].name')
+          if echo "$LABELS" | grep -q "^hold$"; then
+            echo "PR #$PR has 'hold' label — skipping Final Audit"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ============================================================
+  # Phase 1: SSOT準拠最終確認
+  # ============================================================
+  phase1-ssot:
+    name: "Phase 1: SSOT準拠確認"
+    runs-on: ubuntu-latest
+    needs: guard
+    if: needs.guard.outputs.skip == 'false' && needs.guard.outputs.pr_number != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Phase 1 — SSOT Compliance Check
+        id: ssot_check
+        run: |
+          # Run framework audit ssot and capture output
+          node dist/cli/index.js audit ssot --json > /tmp/ssot-result.json 2>&1 || true
+          cat /tmp/ssot-result.json
+
+          # Check for MUST requirement failures
+          if node -e "
+            const r = require('/tmp/ssot-result.json');
+            const failed = (r.issues || []).filter(i => i.severity === 'must');
+            if (failed.length > 0) {
+              console.error('MUST failures:', failed.map(f => f.message).join(', '));
+              process.exit(1);
+            }
+          " 2>/dev/null; then
+            echo "phase1_result=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "phase1_result=fail" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+  # ============================================================
+  # Phase 2: コード監査（100点スコアカード）
+  # ============================================================
+  phase2-code:
+    name: "Phase 2: コード監査スコアカード"
+    runs-on: ubuntu-latest
+    needs: [guard, phase1-ssot]
+    if: needs.guard.outputs.skip == 'false' && needs.guard.outputs.pr_number != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Phase 2 — Code Audit Scorecard
+        id: code_audit
+        run: |
+          node dist/cli/index.js audit code --json > /tmp/code-result.json 2>&1 || true
+          cat /tmp/code-result.json
+
+          SCORE=$(node -e "
+            try {
+              const r = require('/tmp/code-result.json');
+              console.log(r.score || 0);
+            } catch { console.log(0); }
+          " 2>/dev/null || echo "0")
+
+          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
+          echo "Code audit score: $SCORE"
+
+          if [ "$SCORE" -lt 70 ]; then
+            echo "❌ Code audit score $SCORE is below threshold (70)"
+            exit 1
+          fi
+          echo "✅ Code audit score: $SCORE/100"
+
+  # ============================================================
+  # Phase 3: 破壊的変更チェック
+  # ============================================================
+  phase3-breaking:
+    name: "Phase 3: 破壊的変更チェック"
+    runs-on: ubuntu-latest
+    needs: [guard, phase1-ssot, phase2-code]
+    if: needs.guard.outputs.skip == 'false' && needs.guard.outputs.pr_number != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Phase 3 — Breaking Change Detection
+        id: breaking_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ needs.guard.outputs.pr_number }}"
+
+          # Check PR body for breaking change declaration
+          PR_BODY=$(gh pr view "$PR" \
+            --repo "${{ github.repository }}" \
+            --json body --jq '.body')
+
+          BREAKING_DECLARED=$(echo "$PR_BODY" | grep -ci "breaking.change\|破壊的変更" || true)
+
+          # Check for API contract changes
+          API_CHANGED=$(git diff origin/main...HEAD -- \
+            "**/*.contract.*" "**/*api*" "src/cli/lib/*-model.ts" \
+            --name-only 2>/dev/null | wc -l || echo "0")
+
+          # Check for DB schema changes
+          DB_CHANGED=$(git diff origin/main...HEAD -- \
+            "**/prisma/**" "**/migrations/**" "**/schema.*" \
+            --name-only 2>/dev/null | wc -l || echo "0")
+
+          # Check for env var changes
+          ENV_CHANGED=$(git diff origin/main...HEAD -- \
+            ".env*" "**/.env*" \
+            --name-only 2>/dev/null | wc -l || echo "0")
+
+          echo "API changes: $API_CHANGED, DB changes: $DB_CHANGED, ENV changes: $ENV_CHANGED"
+          echo "Breaking declared in PR: $BREAKING_DECLARED"
+
+          # If potentially breaking but not declared → fail
+          TOTAL_RISK=$((API_CHANGED + DB_CHANGED + ENV_CHANGED))
+          if [ "$TOTAL_RISK" -gt 0 ] && [ "$BREAKING_DECLARED" -eq 0 ]; then
+            echo "⚠️  Breaking changes detected but not declared in PR body."
+            echo "Please add 'Breaking Change: <description>' to the PR body."
+            exit 1
+          fi
+
+          echo "✅ Phase 3 passed"
+
+  # ============================================================
+  # Final: 全フェーズ合格 → ラベル付与 + PR コメント
+  # ============================================================
+  audit-complete:
+    name: Audit Complete
+    runs-on: ubuntu-latest
+    needs: [guard, phase1-ssot, phase2-code, phase3-breaking]
+    if: always() && needs.guard.outputs.pr_number != ''
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Evaluate audit results
+        id: evaluate
+        run: |
+          P1="${{ needs.phase1-ssot.result }}"
+          P2="${{ needs.phase2-code.result }}"
+          P3="${{ needs.phase3-breaking.result }}"
+
+          if [[ "$P1" == "success" && "$P2" == "success" && "$P3" == "success" ]]; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Label PR (pass)
+        if: steps.evaluate.outputs.result == 'pass'
+        run: |
+          PR="${{ needs.guard.outputs.pr_number }}"
+          gh pr edit "$PR" \
+            --repo "${{ github.repository }}" \
+            --add-label "audit-passed" \
+            --remove-label "audit-failed" || true
+
+      - name: Label PR (fail)
+        if: steps.evaluate.outputs.result == 'fail'
+        run: |
+          PR="${{ needs.guard.outputs.pr_number }}"
+          gh pr edit "$PR" \
+            --repo "${{ github.repository }}" \
+            --add-label "audit-failed" \
+            --remove-label "audit-passed" || true
+
+      - name: Comment on PR
+        run: |
+          PR="${{ needs.guard.outputs.pr_number }}"
+          RESULT="${{ steps.evaluate.outputs.result }}"
+          P1="${{ needs.phase1-ssot.result }}"
+          P2="${{ needs.phase2-code.result }}"
+          P3="${{ needs.phase3-breaking.result }}"
+
+          if [ "$RESULT" = "pass" ]; then
+            EMOJI="✅"
+            SUMMARY="**最終監査: 全フェーズ合格**\n\nマージ承認をお願いします。"
+          else
+            EMOJI="❌"
+            SUMMARY="**最終監査: 不合格**\n\n修正後に再プッシュしてください。"
+          fi
+
+          gh pr comment "$PR" \
+            --repo "${{ github.repository }}" \
+            --body "## $EMOJI Final Audit 結果
+
+          | Phase | 内容 | 結果 |
+          |-------|------|------|
+          | Phase 1 | SSOT準拠確認 | $( [ "$P1" = "success" ] && echo "✅ Pass" || echo "❌ Fail" ) |
+          | Phase 2 | コード監査スコアカード | $( [ "$P2" = "success" ] && echo "✅ Pass" || echo "❌ Fail" ) |
+          | Phase 3 | 破壊的変更チェック | $( [ "$P3" = "success" ] && echo "✅ Pass" || echo "❌ Fail" ) |
+
+          $SUMMARY"

--- a/docs/TASK-SEQUENCE-DESIGN.md
+++ b/docs/TASK-SEQUENCE-DESIGN.md
@@ -151,13 +151,26 @@ GitHub Issues のラベルも自動更新する。
 
 ---
 
-## 6. review → merge → 次タスク フロー
+## 6. PR → 最終監査 → マージ → 次タスク フロー
 
 ```
 実装完了
   → PR 作成（本文に Closes #xxx 必須）
-  → R1-R5 Review Council → Approve
-  → main マージ
+  → CI 実行（pull_request trigger）
+  → CI 全通過
+  → 最終監査（Final Audit）3フェーズ自動実行
+       Phase 1: SSOT準拠最終確認（全MUST要件）
+       Phase 2: コード監査（100点スコアカード）
+       Phase 3: 破壊的変更・デプロイ影響チェック
+                （API契約変更 / DBスキーマ変更 / env vars / マイグレーション有無）
+  → 全フェーズ合格
+  → マージ承認要求
+       ├── GitHub: Required Reviewer に Approve 要求
+       └── Telegram 通知（PR URL・監査結果サマリー）
+  → CEO: Telegram で承認 → GitHub で Approve 実行
+  → Squash & Merge
+  → main CI 再実行 → Staging 自動デプロイ
+  → GitHub Projects → Done
   → CI hook: framework sync 自動実行（atomic write）
        → GitHub Issue 自動 close
        → plan.json 更新
@@ -165,6 +178,19 @@ GitHub Issues のラベルも自動更新する。
        → 最小 WWWFFFFTTT の todo を返す
        → 次タスク開始
 ```
+
+### 最終監査フェーズ詳細
+
+| Phase | 内容 | 判定 |
+|-------|------|------|
+| Phase 1 | SSOT全MUST要件準拠確認 | 1件でも不備 → Reject |
+| Phase 2 | コード監査 100点スコアカード | 閾値未満 → Reject |
+| Phase 3 | 破壊的変更チェック（API契約 / DBスキーマ / env vars / migration） | 未申告の破壊的変更 → Reject |
+
+### 人間による停止
+
+- PR に `hold` ラベルを付与 → 自動マージをスキップ
+- `framework block <PR番号>` でラベル付与可能
 
 ---
 


### PR DESCRIPTION
## 参照SSOT
docs/TASK-SEQUENCE-DESIGN.md §6

## 概要
CI全通過後に自動で3フェーズ最終監査を実行するworkflowを追加。

## 変更内容
- `.github/workflows/final-audit.yml` 新規追加
- `docs/TASK-SEQUENCE-DESIGN.md` フロー追記

## 仕様
- guard: CIがsuccess かつ holdラベルなし を確認
- Phase 1: SSOT準拠確認
- Phase 2: コード監査スコアカード（70点以上で合格）
- Phase 3: 破壊的変更未申告を検出
- 全合格 → `audit-passed`ラベル + PRコメント
- 不合格 → `audit-failed`ラベル + 失敗フェーズ明示

## テスト・証跡
- TypeScript コンパイルエラーなし（workflow YAMLのみ）

## CI
ローカル確認済み（YAML構文）

Closes #25