### PR TITLE
feat: CEO承認 → 自動マージ + framework block/unblock (#27 #28)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,53 @@
+name: Auto Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto-merge:
+    name: Squash & Merge after Approve
+    runs-on: ubuntu-latest
+    if: github.event.review.state == 'approved'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check labels
+        id: check
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          LABELS=$(gh pr view "$PR" \
+            --repo "${{ github.repository }}" \
+            --json labels \
+            --jq '.labels[].name')
+
+          if echo "$LABELS" | grep -q "^hold$"; then
+            echo "PR #$PR has 'hold' label — skipping auto-merge"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! echo "$LABELS" | grep -q "^audit-passed$"; then
+            echo "PR #$PR does not have 'audit-passed' label — skipping auto-merge"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Squash & Merge
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          gh pr merge "$PR" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --auto \
+            --delete-branch
+          echo "✅ PR #$PR merged (squash)"
+
+      - name: Update GitHub Projects → Done
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          echo "GitHub Projects update — Done"
+          # Projects V2 update is handled via post-merge CI on main

--- a/src/cli/commands/block.ts
+++ b/src/cli/commands/block.ts
@@ -1,0 +1,50 @@
+/**
+ * framework block / framework unblock
+ *
+ * Add or remove the 'hold' label on a PR to prevent / resume auto-merge.
+ *
+ * Design: docs/TASK-SEQUENCE-DESIGN.md §6
+ * Issue: #28
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { type Command } from "commander";
+import { logger } from "../lib/logger.js";
+
+const execFileAsync = promisify(execFile);
+
+async function gh(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("gh", args);
+  return stdout.trim();
+}
+
+export function registerBlockCommand(program: Command): void {
+  program
+    .command("block")
+    .description("Add 'hold' label to PR — prevent auto-merge")
+    .argument("<pr>", "PR number")
+    .action(async (pr: string) => {
+      try {
+        await gh(["pr", "edit", pr, "--add-label", "hold"]);
+        logger.success(`PR #${pr}: 'hold' ラベルを付与しました。自動マージは停止されます。`);
+        logger.info("  解除するには: framework unblock " + pr);
+      } catch (err) {
+        logger.error(`PR #${pr} へのラベル付与に失敗しました: ${err}`);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command("unblock")
+    .description("Remove 'hold' label from PR — resume auto-merge")
+    .argument("<pr>", "PR number")
+    .action(async (pr: string) => {
+      try {
+        await gh(["pr", "edit", pr, "--remove-label", "hold"]);
+        logger.success(`PR #${pr}: 'hold' ラベルを削除しました。自動マージが再開されます。`);
+      } catch (err) {
+        logger.error(`PR #${pr} のラベル削除に失敗しました: ${err}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import { registerGateCommand } from "./commands/gate.js";
 import { registerFeedbackCommand } from "./commands/feedback.js";
 import { registerProjectsCommand } from "./commands/projects.js";
 import { registerNextCommand } from "./commands/next.js";
+import { registerBlockCommand } from "./commands/block.js";
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -52,6 +53,7 @@ registerGateCommand(program);
 registerAuditCommand(program);
 registerRunCommand(program);
 registerNextCommand(program);
+registerBlockCommand(program);
 registerStatusCommand(program);
 
 // Project management


### PR DESCRIPTION
## 参照SSOT
docs/TASK-SEQUENCE-DESIGN.md §6

## 概要
Issue #27/#28 の実装。

## 変更内容
**auto-merge.yml（#27）**
- pull_request_review(approved) をトリガーに Squash & Merge を自動実行
- audit-passed ラベル必須、hold ラベルがある場合はスキップ

**commands/block.ts（#28）**
- `framework block <PR>`: hold ラベル付与
- `framework unblock <PR>`: hold ラベル削除

## テスト・証跡
- TypeScript コンパイルエラーなし

## CI
ローカル確認済み

Closes #27
Closes #28