### PR TITLE
fix(plan-model): atomic write for savePlan() [WARN-1]

### DIFF
--- a/src/cli/lib/plan-model.ts
+++ b/src/cli/lib/plan-model.ts
@@ -394,6 +394,7 @@ export function assignSeqNumbers(waves: Wave[], tasks: Task[]): void {
 // ─────────────────────────────────────────────
 
 const PLAN_FILE = ".framework/plan.json";
+const PLAN_TMP = ".framework/plan.json.tmp";
 
 export function loadPlan(projectDir: string): PlanState | null {
   const filePath = path.join(projectDir, PLAN_FILE);
@@ -407,12 +408,36 @@ export function loadPlan(projectDir: string): PlanState | null {
   return parsed;
 }
 
+/**
+ * Save plan.json with atomic write (tmp + rename) to prevent corruption on crash.
+ * Uses the same pattern as sync-engine.ts atomicWritePlan().
+ */
 export function savePlan(projectDir: string, plan: PlanState): void {
-  const filePath = path.join(projectDir, PLAN_FILE);
-  const dir = path.dirname(filePath);
+  const planFilePath = path.join(projectDir, PLAN_FILE);
+  const tmpFilePath = path.join(projectDir, PLAN_TMP);
+  const dir = path.dirname(planFilePath);
+
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  plan.updatedAt = new Date().toISOString();
-  fs.writeFileSync(filePath, JSON.stringify(plan, null, 2), "utf-8");
+
+  try {
+    // Write to tmp
+    plan.updatedAt = new Date().toISOString();
+    fs.writeFileSync(
+      tmpFilePath,
+      JSON.stringify(plan, null, 2),
+      "utf-8",
+    );
+    // Atomic rename
+    fs.renameSync(tmpFilePath, planFilePath);
+  } catch (err) {
+    // Cleanup tmp on failure
+    try {
+      fs.rmSync(tmpFilePath, { force: true });
+    } catch {
+      /* ignore cleanup errors */
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## WARN-1 修正

### 問題
`savePlan()` が `fs.writeFileSync` で直接書き込みを行っており、plan 生成中にクラッシュすると plan.json が壊れる可能性があった。

### 修正内容
- `savePlan()` を atomic write に変更
- `.framework/plan.json.tmp` に一時書き込み → atomic rename
- 失敗時は tmp ファイルをクリーンアップ
- `sync-engine.ts` の `atomicWritePlan()` と同じパターンに統一

### 影響範囲
- plan 生成・更新時のデータ破損リスク解消
- 既存の動作には影響なし（atomic rename は透過的）

関連: 監査レビュー WARN-1