### PR TITLE
feat(oss-prep): OSS公開前改修 A-E（決定論的制御強化）

### DIFF
--- a/.framework/config.json
+++ b/.framework/config.json
@@ -1,0 +1,9 @@
+{
+  "provider": {
+    "default": "claude",
+    "remediation": "claude",
+    "validation": "claude",
+    "ingestion": "claude",
+    "worktree": "claude"
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Pre-commit hook for ai-dev-framework.
+#
+# Runs docs/specs/06_CODE_QUALITY.md §1.3/§3.4/§4.4 content-level checks.
+# Bypass (not recommended): git commit --no-verify
+#
+bash "$(git rev-parse --show-toplevel)/scripts/pre-commit-checks.sh"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ AI駆動の開発フレームワーク。曖昧なプロダクトアイデアか
 ### 前提条件
 - Node.js 18+
 - npm
+- Claude Code CLI (`claude`) **or** Codex CLI (`codex`) — at least one LLM provider required
+
+### LLMプロバイダー設定
+
+`.framework/config.json` の `provider` セクションで切り替えます:
+
+```json
+{
+  "provider": {
+    "default": "claude",
+    "remediation": "claude",
+    "validation": "claude",
+    "ingestion": "claude",
+    "worktree": "claude"
+  }
+}
+```
+
+- `default`: 全般デフォルト
+- `remediation`: 自動修正（Gate BLOCK後）
+- `validation`: Validator実行（Gate 2）
+- `ingestion`: 設計書取り込み（`framework ingest`）
+- `worktree`: 並列タスク実行
+
+設定ファイルがない場合、`claude` → `codex` の優先順で自動検出します。
+利用可能なプロバイダー: `claude`, `codex`。
 
 ### インストール
 ```bash

--- a/docs/proposals/spec-addition-06-llm-provider.md
+++ b/docs/proposals/spec-addition-06-llm-provider.md
@@ -1,0 +1,69 @@
+# 仕様書追記提案: LLMプロバイダー設定
+
+## 追記先
+`docs/specs/06_CODE_QUALITY_v1.0.0.md` の末尾（変更履歴の前）
+
+## ステータス
+**提案中** — CEOレビュー待ち
+
+## 提案理由
+改修D（LLMプロバイダー抽象化）の導入により、Validator / remediation / ingestion / worktree 実行時に使用するLLMプロバイダーを切り替え可能になった。OSS公開時に Claude Code / Codex CLI の両方をサポートするため、`06_CODE_QUALITY.md` に以下を追記する必要がある。
+
+## 追記内容（新規セクション: 7章）
+
+```markdown
+## 7. LLMプロバイダー構成
+
+### 7.1 プロバイダー設定
+
+`.framework/config.json` の `provider` セクションで、役割ごとに使用する LLM プロバイダーを切り替える:
+
+| 役割 | 用途 | デフォルト |
+|-----|------|-----------|
+| `default` | 全般 | 自動検出（claude → codex） |
+| `remediation` | 自動修正（Gate BLOCK後） | `default` を継承 |
+| `validation` | Validator 実行（Gate 2） | `default` を継承 |
+| `ingestion` | 設計書取り込み（`framework ingest`） | `default` を継承 |
+| `worktree` | 並列タスク実行 | `default` を継承 |
+
+### 7.2 設定例
+
+```json
+{
+  "provider": {
+    "default": "claude",
+    "validation": "codex"
+  }
+}
+```
+
+### 7.3 サポート済みプロバイダー
+
+- `claude`: Anthropic Claude Code CLI (`claude -p "<prompt>"`)
+- `codex`: OpenAI Codex CLI (`codex exec --full-auto "<prompt>"`)
+
+### 7.4 自動検出
+
+`.framework/config.json` が存在しない or `provider` セクションが無効な場合:
+1. `claude` コマンドが PATH にあれば `claude` を選択
+2. そうでなければ `codex` を選択
+3. どちらも無ければ `claude`（実行時エラーとなるが、README に記載された前提条件を参照）
+
+### 7.5 OSS利用時の前提条件
+
+ユーザーは以下いずれか1つ以上を事前インストール:
+- Claude Code CLI
+- Codex CLI
+
+README の "前提条件" に明記すること。
+```
+
+## 承認フロー
+1. CEOが本提案をレビュー
+2. 承認後、`framework feedback approve <id>` 経由で docs/specs/06_CODE_QUALITY.md に自動追記
+
+## 関連変更
+- `src/cli/lib/llm-provider.ts` 新規
+- `src/cli/lib/gate-quality-engine.ts` / `auto-remediation.ts` / `worktree-manager.ts` / `ingest-engine.ts` 置換
+- `.framework/config.json` / `templates/project/.framework/config.json` 追加
+- `README.md` 前提条件セクション更新

--- a/scripts/pre-commit-checks.sh
+++ b/scripts/pre-commit-checks.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Pre-commit content-level checks based on docs/specs/06_CODE_QUALITY.md:
+#   §1.3 #8 (完全性):   no console.log in production source (non-test)
+#   §3.4 (作成原則):     no .skip / .only in test files
+#   §1.3 #4 (セキュリティ): hardcoded secret detection
+#   §4.4 (CI合格条件):   front-load a subset of required CI checks
+#
+# Escape hatches (place in the file as a comment):
+#   // pre-commit-allow: console-log    — file may contain console.log
+#                                         (e.g., hook-script generators)
+#   // pre-commit-allow: skip-only      — file may contain .skip/.only inside
+#                                         string fixtures demonstrating them
+#   // pre-commit-allow: secret         — file may contain hardcoded test tokens
+#
+# Per-line escape:
+#   // allowed                          — single-line exemption for console.log
+#
+# Bypass entire script: git commit --no-verify (NOT recommended)
+#
+set -e
+ERRORS=0
+
+say() { printf "%s\n" "$*"; }
+
+# file_has_allow <file> <token>  — returns 0 if file opts out of the named check.
+file_has_allow() {
+  grep -q "pre-commit-allow: $2" "$1" 2>/dev/null
+}
+
+# ─────────────────────────────────────────────
+# §1.3 #8 完全性: console.log detection (production src only)
+# ─────────────────────────────────────────────
+CONSOLE_LOGS_ALL=$(grep -rEln "(^|\s|;|\{)console\.log\s*\(" \
+  --include="*.ts" --include="*.tsx" src/ 2>/dev/null || true)
+CONSOLE_ERRORS=""
+for f in $CONSOLE_LOGS_ALL; do
+  case "$f" in
+    *.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx) continue ;;
+  esac
+  if file_has_allow "$f" "console-log"; then continue; fi
+  hits=$(grep -En "(^|\s|;|\{)console\.log\s*\(" "$f" | grep -v "// allowed" || true)
+  if [ -n "$hits" ]; then
+    CONSOLE_ERRORS="${CONSOLE_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$CONSOLE_ERRORS" ]; then
+  say ""
+  say "ERROR: console.log found (docs/specs/06_CODE_QUALITY.md §1.3 #8 完全性 violation):"
+  printf "%b" "$CONSOLE_ERRORS"
+  say ""
+  say "  Fix: remove console.log from production code, append '// allowed' to a single"
+  say "       line, or add '// pre-commit-allow: console-log' to the file if it"
+  say "       intentionally generates scripts containing console.log."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# §3.4 テスト作成原則: .skip / .only / xdescribe
+# ─────────────────────────────────────────────
+SKIP_FILES=$(grep -rEln "(describe|it|test)\.(skip|only)\s*\(|\b(xdescribe|xit|xtest)\s*\(" \
+  --include="*.test.ts" --include="*.test.tsx" --include="*.spec.ts" --include="*.spec.tsx" \
+  . 2>/dev/null | grep -v node_modules | grep -v dist || true)
+SKIP_ERRORS=""
+for f in $SKIP_FILES; do
+  if file_has_allow "$f" "skip-only"; then continue; fi
+  hits=$(grep -En "(describe|it|test)\.(skip|only)\s*\(|\b(xdescribe|xit|xtest)\s*\(" "$f" || true)
+  if [ -n "$hits" ]; then
+    SKIP_ERRORS="${SKIP_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$SKIP_ERRORS" ]; then
+  say ""
+  say "ERROR: .skip / .only / xdescribe found in tests (docs/specs/06_CODE_QUALITY.md §3.4 violation):"
+  printf "%b" "$SKIP_ERRORS"
+  say ""
+  say "  Fix: remove .skip/.only. Skipped tests are forbidden in the main branch."
+  say "       For files containing string fixtures demonstrating the pattern,"
+  say "       add '// pre-commit-allow: skip-only' to the file."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# §1.3 #4 セキュリティ: hardcoded secret detection
+# ─────────────────────────────────────────────
+SECRET_FILES=$(grep -rEln "(sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|ghp_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,})" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" src/ 2>/dev/null || true)
+SECRET_ERRORS=""
+for f in $SECRET_FILES; do
+  if file_has_allow "$f" "secret"; then continue; fi
+  hits=$(grep -En "(sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|ghp_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,})" "$f" | grep -v "// allowed-secret" || true)
+  if [ -n "$hits" ]; then
+    SECRET_ERRORS="${SECRET_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$SECRET_ERRORS" ]; then
+  say ""
+  say "ERROR: potential hardcoded secret (docs/specs/06_CODE_QUALITY.md §1.3 #4 セキュリティ violation):"
+  printf "%b" "$SECRET_ERRORS"
+  say ""
+  say "  Fix: move to environment variable, append '// allowed-secret' per line,"
+  say "       or add '// pre-commit-allow: secret' to the file if it contains test fixtures."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# Verdict
+# ─────────────────────────────────────────────
+if [ $ERRORS -gt 0 ]; then
+  say ""
+  say "Pre-commit checks failed ($ERRORS errors). See docs/specs/06_CODE_QUALITY.md."
+  say "Emergency bypass (not recommended): git commit --no-verify"
+  exit 1
+fi
+
+say "OK Pre-commit content checks passed"
+exit 0

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,0 +1,24 @@
+import type { Command } from "commander";
+import { checkTests, formatTestQualityReport } from "../lib/test-quality-checker.js";
+
+export function registerCheckCommand(program: Command): void {
+  const check = program
+    .command("check")
+    .description("Deterministic pre-checks (tests, etc.)");
+
+  check
+    .command("tests")
+    .description(
+      "Scan test files for fake-test patterns (§3.3/§3.4 of docs/specs/06_CODE_QUALITY.md)",
+    )
+    .option("--json", "Output machine-readable JSON")
+    .action((options: { json?: boolean }) => {
+      const result = checkTests(process.cwd());
+      if (options.json) {
+        process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } else {
+        process.stdout.write(formatTestQualityReport(result) + "\n");
+      }
+      if (result.verdict === "BLOCK") process.exit(1);
+    });
+}

--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -41,7 +41,7 @@ import {
 } from "../lib/gate-quality-engine.js";
 import {
   qualitySweepToJSON,
-  gate3VerdictToJSON,
+  buildGateContextJSON,
 } from "../lib/gate-json-output.js";
 import { loadProviderConfig } from "../lib/llm-provider.js";
 
@@ -575,19 +575,18 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
           logger.info("");
 
           if (jsonMode) {
+            // Context-collection phase emits GateContextJSON (NO verdict field).
+            // The actual Ship/Block verdict is produced later by the
+            // /gate-release skill, which should emit a separate GateResultJSON.
+            // Emitting a fake "SHIP" here would be dishonest and could be
+            // misread by machine consumers as a real green-light decision.
             const providerConfig = loadProviderConfig(projectDir);
-            const json = gate3VerdictToJSON({
-              verdict: "SHIP",
+            const json = buildGateContextJSON({
+              gate: "release",
               provider: providerConfig.default,
-              elapsedMs: 0,
-              rawReport: "Context collected. Actual verdict is emitted by /gate-release skill.",
-            });
-            // Override gate so consumers can distinguish "context-only" from real verdict.
-            json.meta = {
-              ...(json.meta ?? {}),
-              status: "context-collected",
               contextPath: ".framework/gate-context/adversarial-review.md",
-            };
+              meta: { nextStep: "/gate-release skill (trial structure)" },
+            });
             process.stdout.write(JSON.stringify(json, null, 2) + "\n");
             restoreLogger?.();
           }

--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -39,6 +39,11 @@ import {
   runQualitySweep,
   formatSweepOutput,
 } from "../lib/gate-quality-engine.js";
+import {
+  qualitySweepToJSON,
+  gate3VerdictToJSON,
+} from "../lib/gate-json-output.js";
+import { loadProviderConfig } from "../lib/llm-provider.js";
 
 export function registerGateCommand(program: Command): void {
   const gate = program
@@ -434,9 +439,16 @@ ${contextBody}
     .option("--branch <branch>", "Branch to diff against", "main")
     .option("--auto-fix", "Auto-remediate BLOCK findings (opt-in)")
     .option("--max-retries <n>", "Max auto-fix retries (default: 2, hard limit: 3)", "2")
+    .option("--output <format>", "Output format (text|json). When json, stdout=JSON, stderr=logs.", "text")
     .action(
-      async (options: { branch: string; autoFix?: boolean; maxRetries?: string }) => {
+      async (options: { branch: string; autoFix?: boolean; maxRetries?: string; output?: string }) => {
         const projectDir = process.cwd();
+        const jsonMode = options.output === "json";
+        let restoreLogger: (() => void) | undefined;
+        if (jsonMode) {
+          const { redirectInfoToStderr } = await import("../lib/logger.js");
+          restoreLogger = redirectInfoToStderr();
+        }
 
         logger.header("Gate 3 — Adversarial Review Context Collection");
         logger.info("");
@@ -561,6 +573,24 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
             logger.info("  After BLOCK verdict, auto-remediation will execute.");
           }
           logger.info("");
+
+          if (jsonMode) {
+            const providerConfig = loadProviderConfig(projectDir);
+            const json = gate3VerdictToJSON({
+              verdict: "SHIP",
+              provider: providerConfig.default,
+              elapsedMs: 0,
+              rawReport: "Context collected. Actual verdict is emitted by /gate-release skill.",
+            });
+            // Override gate so consumers can distinguish "context-only" from real verdict.
+            json.meta = {
+              ...(json.meta ?? {}),
+              status: "context-collected",
+              contextPath: ".framework/gate-context/adversarial-review.md",
+            };
+            process.stdout.write(JSON.stringify(json, null, 2) + "\n");
+            restoreLogger?.();
+          }
         } catch (error) {
           if (error instanceof Error) {
             logger.error(`Gate release error: ${error.message}`);
@@ -582,9 +612,16 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
     .option("--context-only", "Only collect context, skip validator execution")
     .option("--auto-fix", "Auto-remediate BLOCK findings (opt-in)")
     .option("--max-retries <n>", "Max auto-fix retries (default: 2, hard limit: 3)", "2")
+    .option("--output <format>", "Output format (text|json). When json, stdout=JSON, stderr=logs.", "text")
     .action(
-      async (options: { branch: string; phase: string; full?: boolean; sequential?: boolean; timeout?: string; contextOnly?: boolean; autoFix?: boolean; maxRetries?: string }) => {
+      async (options: { branch: string; phase: string; full?: boolean; sequential?: boolean; timeout?: string; contextOnly?: boolean; autoFix?: boolean; maxRetries?: string; output?: string }) => {
         const projectDir = process.cwd();
+        const jsonMode = options.output === "json";
+        let restoreLogger: (() => void) | undefined;
+        if (jsonMode) {
+          const { redirectInfoToStderr } = await import("../lib/logger.js");
+          restoreLogger = redirectInfoToStderr();
+        }
 
         logger.header("Gate 2 — Quality Sweep Context Collection");
         logger.info("");
@@ -710,6 +747,15 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
             timeoutMs: parseInt(options.timeout ?? "120", 10) * 1000,
             warningThreshold,
           });
+
+          if (jsonMode) {
+            const providerConfig = loadProviderConfig(projectDir);
+            const json = qualitySweepToJSON(sweepResult, providerConfig.default);
+            process.stdout.write(JSON.stringify(json, null, 2) + "\n");
+            restoreLogger?.();
+            if (sweepResult.verdict === "BLOCK") process.exit(1);
+            return;
+          }
 
           // Display results
           const output = formatSweepOutput(sweepResult);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,7 @@ import { registerPruneCommand } from "./commands/prune.js";
 import { registerConfigCommand } from "./commands/config.js";
 import { registerImproveCommand } from "./commands/improve.js";
 import { registerIngestCommand } from "./commands/ingest.js";
+import { registerCheckCommand } from "./commands/check.js";
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -67,6 +68,9 @@ registerStatusCommand(program);
 
 // Design ingest
 registerIngestCommand(program);
+
+// Deterministic pre-checks
+registerCheckCommand(program);
 
 // Project management
 registerRetrofitCommand(program);

--- a/src/cli/lib/auto-remediation.ts
+++ b/src/cli/lib/auto-remediation.ts
@@ -10,7 +10,12 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { execSync, type ExecSyncOptions } from "node:child_process";
+import { execSync } from "node:child_process";
+import {
+  executeWithProvider,
+  getProvider,
+  loadProviderConfig,
+} from "./llm-provider.js";
 
 // ─────────────────────────────────────────────
 // Types
@@ -216,21 +221,14 @@ export async function executeRemediation(
     // Ignore diff errors
   }
 
-  // Execute remediation via claude -p
-  const execOpts: ExecSyncOptions = {
-    cwd: projectDir,
-    encoding: "utf-8" as const,
-    timeout: timeout * 1000,
-    maxBuffer: 10 * 1024 * 1024,
-    stdio: ["pipe", "pipe", "pipe"],
-  };
-
+  // Execute remediation via configured LLM provider
   try {
-    const promptContent = instruction.instruction.replace(/'/g, "'\\''");
-    execSync(
-      `claude -p '${promptContent}'`,
-      execOpts,
-    );
+    const providerConfig = loadProviderConfig(projectDir);
+    const provider = getProvider("remediation", providerConfig);
+    await executeWithProvider(provider, instruction.instruction, {
+      cwd: projectDir,
+      timeoutMs: timeout * 1000,
+    });
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     if (errMsg.includes("TIMEOUT") || errMsg.includes("timed out")) {

--- a/src/cli/lib/ci-model.ts
+++ b/src/cli/lib/ci-model.ts
@@ -4,6 +4,9 @@
  *
  * Six CI stages: lint, unit-test, integration-test, build, e2e, security
  * All required stages must pass for "ready" verdict.
+ *
+ * pre-commit-allow: console-log
+ * (this file reports on detected console.log usage and contains literal strings describing them)
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/src/cli/lib/gate-json-output.test.ts
+++ b/src/cli/lib/gate-json-output.test.ts
@@ -3,6 +3,7 @@ import {
   parseFindingString,
   qualitySweepToJSON,
   gate3VerdictToJSON,
+  buildGateContextJSON,
 } from "./gate-json-output.js";
 import type { QualitySweepResult } from "./gate-quality-engine.js";
 
@@ -119,5 +120,37 @@ describe("gate3VerdictToJSON", () => {
     expect(json.verdict).toBe("SHIP_WITH_CONDITIONS");
     expect(json.validators[0].name).toBe("Prosecutor");
     expect((json.meta?.conditions as string[]).length).toBe(2);
+  });
+});
+
+describe("buildGateContextJSON (honesty-by-construction)", () => {
+  it("omits the verdict field entirely so consumers cannot misread context as a verdict", () => {
+    const json = buildGateContextJSON({
+      gate: "release",
+      provider: "claude",
+      contextPath: ".framework/gate-context/adversarial-review.md",
+    });
+    expect(json.gate).toBe("release");
+    expect(json.stage).toBe("context-collected");
+    expect(json.provider).toBe("claude");
+    expect(json.contextPath).toBe(
+      ".framework/gate-context/adversarial-review.md",
+    );
+    // Critical: no `verdict` field at all.
+    expect("verdict" in json).toBe(false);
+  });
+
+  it("includes a timestamp and round-trips through JSON.stringify/parse", () => {
+    const json = buildGateContextJSON({
+      gate: "quality",
+      provider: "codex",
+      contextPath: ".framework/gate-context/quality-sweep.md",
+      meta: { nextStep: "run validators" },
+    });
+    const parsed = JSON.parse(JSON.stringify(json));
+    expect(parsed.stage).toBe("context-collected");
+    expect(new Date(parsed.timestamp).toString()).not.toBe("Invalid Date");
+    expect(parsed.meta.nextStep).toBe("run validators");
+    expect("verdict" in parsed).toBe(false);
   });
 });

--- a/src/cli/lib/gate-json-output.test.ts
+++ b/src/cli/lib/gate-json-output.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFindingString,
+  qualitySweepToJSON,
+  gate3VerdictToJSON,
+} from "./gate-json-output.js";
+import type { QualitySweepResult } from "./gate-quality-engine.js";
+
+describe("parseFindingString", () => {
+  it("extracts id, category, message, file and line", () => {
+    const f = parseFindingString(
+      "- [SEC-001] SQL injection in db.ts (src/db.ts:42)",
+      "CRITICAL",
+    );
+    expect(f.id).toBe("SEC-001");
+    expect(f.category).toBe("sec");
+    expect(f.severity).toBe("CRITICAL");
+    expect(f.file).toBe("src/db.ts");
+    expect(f.line).toBe(42);
+    expect(f.message).toMatch(/SQL injection/);
+  });
+
+  it("falls back to message-only when unparsable", () => {
+    const f = parseFindingString("random finding text", "WARNING");
+    expect(f.id).toBe("UNKNOWN");
+    expect(f.message).toBe("random finding text");
+  });
+});
+
+describe("qualitySweepToJSON", () => {
+  it("produces §6.1-shaped JSON", () => {
+    const input: QualitySweepResult = {
+      validators: [
+        {
+          name: "SSOT Drift",
+          critical: 1,
+          warning: 2,
+          info: 0,
+          criticalFindings: ["[SSOT-001] Drift detected (src/foo.ts:10)"],
+          warningFindings: ["[SSOT-010] Minor drift"],
+          rawOutput: "raw",
+          elapsedMs: 1200,
+        },
+      ],
+      totalCritical: 1,
+      totalWarning: 2,
+      totalInfo: 0,
+      verdict: "BLOCK",
+      elapsedMs: 1500,
+      warningThreshold: 5,
+    };
+    const json = qualitySweepToJSON(input, "claude");
+    expect(json.gate).toBe("quality");
+    expect(json.verdict).toBe("BLOCK");
+    expect(json.provider).toBe("claude");
+    expect(json.summary.critical).toBe(1);
+    expect(json.validators).toHaveLength(1);
+    expect(json.validators[0].status).toBe("BLOCK");
+    expect(json.validators[0].findings[0].id).toBe("SSOT-001");
+    expect(json.validators[0].findings[0].file).toBe("src/foo.ts");
+    expect(json.validators[0].findings[0].line).toBe(10);
+  });
+
+  it("marks validator as PASS when critical is 0", () => {
+    const input: QualitySweepResult = {
+      validators: [
+        {
+          name: "Security",
+          critical: 0,
+          warning: 0,
+          info: 0,
+          criticalFindings: [],
+          warningFindings: [],
+          rawOutput: "",
+          elapsedMs: 500,
+        },
+      ],
+      totalCritical: 0,
+      totalWarning: 0,
+      totalInfo: 0,
+      verdict: "PASS",
+      elapsedMs: 600,
+      warningThreshold: 5,
+    };
+    const json = qualitySweepToJSON(input, "codex");
+    expect(json.validators[0].status).toBe("PASS");
+    expect(json.provider).toBe("codex");
+  });
+
+  it("is valid JSON (serializable + parseable)", () => {
+    const input: QualitySweepResult = {
+      validators: [],
+      totalCritical: 0,
+      totalWarning: 0,
+      totalInfo: 0,
+      verdict: "PASS",
+      elapsedMs: 100,
+      warningThreshold: 5,
+    };
+    const json = qualitySweepToJSON(input, "claude");
+    const serialized = JSON.stringify(json);
+    const parsed = JSON.parse(serialized);
+    expect(parsed.verdict).toBe("PASS");
+  });
+});
+
+describe("gate3VerdictToJSON", () => {
+  it("produces a release-gate JSON with SHIP_WITH_CONDITIONS + conditions meta", () => {
+    const json = gate3VerdictToJSON({
+      verdict: "SHIP_WITH_CONDITIONS",
+      provider: "claude",
+      elapsedMs: 300000,
+      rawReport: "...",
+      prosecutorCritical: 0,
+      prosecutorWarning: 3,
+      conditions: ["Add E2E for login", "Document rollback plan"],
+    });
+    expect(json.gate).toBe("release");
+    expect(json.verdict).toBe("SHIP_WITH_CONDITIONS");
+    expect(json.validators[0].name).toBe("Prosecutor");
+    expect((json.meta?.conditions as string[]).length).toBe(2);
+  });
+});

--- a/src/cli/lib/gate-json-output.ts
+++ b/src/cli/lib/gate-json-output.ts
@@ -48,6 +48,41 @@ export interface GateResultJSON {
   meta?: Record<string, unknown>;
 }
 
+/**
+ * Emitted when `framework gate release --output json` (or similar
+ * context-collection command) runs BEFORE an actual verdict is rendered
+ * by the downstream skill. DELIBERATELY omits `verdict` so machine
+ * consumers cannot misread a preparation step as a SHIP decision.
+ *
+ * Honest-by-construction: the verdict arrives in a separate
+ * GateResultJSON after the /gate-release skill produces its
+ * Prosecutor → Defense → Judge output.
+ */
+export interface GateContextJSON {
+  gate: "design" | "quality" | "release";
+  stage: "context-collected";
+  timestamp: string;
+  provider: string;
+  contextPath: string;
+  meta?: Record<string, unknown>;
+}
+
+export function buildGateContextJSON(input: {
+  gate: "design" | "quality" | "release";
+  provider: string;
+  contextPath: string;
+  meta?: Record<string, unknown>;
+}): GateContextJSON {
+  return {
+    gate: input.gate,
+    stage: "context-collected",
+    timestamp: new Date().toISOString(),
+    provider: input.provider,
+    contextPath: input.contextPath,
+    meta: input.meta,
+  };
+}
+
 // ─────────────────────────────────────────────
 // Finding parsing
 // ─────────────────────────────────────────────

--- a/src/cli/lib/gate-json-output.ts
+++ b/src/cli/lib/gate-json-output.ts
@@ -1,0 +1,175 @@
+/**
+ * Structured (JSON) output formatters for Gate results.
+ *
+ * Based on docs/specs/06_CODE_QUALITY.md §6.1 (code-quality audit report)
+ * and §6.2 (test-quality audit report). Human-readable Markdown and
+ * machine-readable JSON are produced from the same data.
+ *
+ * Used by `framework gate quality --output json` and
+ * `framework gate release --output json`.
+ */
+import type { QualitySweepResult } from "./gate-quality-engine.js";
+
+export type Severity = "CRITICAL" | "WARNING" | "INFO";
+
+export interface GateFinding {
+  id: string;
+  severity: Severity;
+  category: string;
+  message: string;
+  file?: string;
+  line?: number;
+}
+
+export interface GateValidatorBlock {
+  name: string;
+  status: "PASS" | "BLOCK";
+  critical: number;
+  warning: number;
+  info: number;
+  elapsedMs: number;
+  findings: GateFinding[];
+  error?: string;
+}
+
+export interface GateResultJSON {
+  gate: "design" | "quality" | "release";
+  verdict: "PASS" | "BLOCK" | "SHIP" | "SHIP_WITH_CONDITIONS";
+  timestamp: string;
+  provider: string;
+  elapsedMs: number;
+  summary: {
+    critical: number;
+    warning: number;
+    info: number;
+    score?: number;
+  };
+  validators: GateValidatorBlock[];
+  meta?: Record<string, unknown>;
+}
+
+// ─────────────────────────────────────────────
+// Finding parsing
+// ─────────────────────────────────────────────
+
+/**
+ * Parse "[CATEGORY-ID] Message (file:line)" finding strings produced by
+ * validators into structured GateFinding objects. Accepts any form — the
+ * raw string is used as the message when parsing fails.
+ */
+export function parseFindingString(raw: string, severity: Severity): GateFinding {
+  const trimmed = raw.trim().replace(/^-\s+/, "").replace(/^\|\s*/, "");
+
+  let id = "UNKNOWN";
+  let category = "general";
+  let rest = trimmed;
+
+  const idMatch = trimmed.match(/^\[([A-Z]+-\d+|[A-Z-]+)\]\s*(.*)$/);
+  if (idMatch) {
+    id = idMatch[1];
+    category = id.split("-")[0].toLowerCase();
+    rest = idMatch[2];
+  }
+
+  let file: string | undefined;
+  let line: number | undefined;
+  const locMatch = rest.match(/\(([^:)]+):(\d+)\)\s*$/);
+  if (locMatch) {
+    file = locMatch[1];
+    line = parseInt(locMatch[2], 10);
+    rest = rest.replace(locMatch[0], "").trim();
+  }
+
+  return { id, severity, category, message: rest, file, line };
+}
+
+// ─────────────────────────────────────────────
+// QualitySweepResult → JSON
+// ─────────────────────────────────────────────
+
+export function qualitySweepToJSON(
+  result: QualitySweepResult,
+  provider: string,
+): GateResultJSON {
+  const validators: GateValidatorBlock[] = result.validators.map((v) => ({
+    name: v.name,
+    status: (v.critical > 0 ? "BLOCK" : "PASS") as "PASS" | "BLOCK",
+    critical: v.critical,
+    warning: v.warning,
+    info: v.info,
+    elapsedMs: v.elapsedMs,
+    findings: [
+      ...v.criticalFindings.map((f) => parseFindingString(f, "CRITICAL")),
+      ...v.warningFindings.map((f) => parseFindingString(f, "WARNING")),
+    ],
+    error: v.error,
+  }));
+
+  return {
+    gate: "quality",
+    verdict: result.verdict,
+    timestamp: new Date().toISOString(),
+    provider,
+    elapsedMs: result.elapsedMs,
+    summary: {
+      critical: result.totalCritical,
+      warning: result.totalWarning,
+      info: result.totalInfo,
+    },
+    validators,
+    meta: {
+      warningThreshold: result.warningThreshold,
+    },
+  };
+}
+
+// ─────────────────────────────────────────────
+// Gate 3 verdict → JSON
+// ─────────────────────────────────────────────
+
+export interface Gate3VerdictInput {
+  verdict: "SHIP" | "SHIP_WITH_CONDITIONS" | "BLOCK";
+  provider: string;
+  elapsedMs: number;
+  rawReport: string;
+  prosecutorCritical?: number;
+  prosecutorWarning?: number;
+  conditions?: string[];
+}
+
+export function gate3VerdictToJSON(input: Gate3VerdictInput): GateResultJSON {
+  const validators: GateValidatorBlock[] = [];
+  if (
+    input.prosecutorCritical !== undefined ||
+    input.prosecutorWarning !== undefined
+  ) {
+    validators.push({
+      name: "Prosecutor",
+      status: (input.prosecutorCritical && input.prosecutorCritical > 0
+        ? "BLOCK"
+        : "PASS") as "PASS" | "BLOCK",
+      critical: input.prosecutorCritical ?? 0,
+      warning: input.prosecutorWarning ?? 0,
+      info: 0,
+      elapsedMs: 0,
+      findings: [],
+    });
+  }
+
+  return {
+    gate: "release",
+    verdict: input.verdict,
+    timestamp: new Date().toISOString(),
+    provider: input.provider,
+    elapsedMs: input.elapsedMs,
+    summary: {
+      critical: input.prosecutorCritical ?? 0,
+      warning: input.prosecutorWarning ?? 0,
+      info: 0,
+    },
+    validators,
+    meta: {
+      conditions: input.conditions ?? [],
+    },
+  };
+}

--- a/src/cli/lib/gate-quality-engine.test.ts
+++ b/src/cli/lib/gate-quality-engine.test.ts
@@ -7,6 +7,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 import {
   parseValidatorOutput,
+  parseValidatorOutputStrict,
+  validateOutputSchema,
+  runValidatorWithRetry,
   runQualitySweep,
   formatSweepOutput,
   setValidatorRunner,
@@ -104,7 +107,7 @@ describe("runQualitySweep", () => {
 
   it("returns PASS when all validators report zero critical and warning <= threshold", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 1\n- Info: 2\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 1\n- Info: 2\n";
     });
 
     const result = await runQualitySweep(tmpDir, { sequential: true });
@@ -119,9 +122,9 @@ describe("runQualitySweep", () => {
     restoreRunner = setValidatorRunner(async () => {
       callCount++;
       if (callCount === 2) {
-        return "### Summary\n- Critical: 1\n- Warning: 0\n\n#### CRITICAL\n- [SEC-001] Bad thing\n";
+        return "### Summary\n- Status: BLOCK\n- Critical: 1\n- Warning: 0\n\n#### CRITICAL\n- [SEC-001] Bad thing\n";
       }
-      return "### Summary\n- Critical: 0\n- Warning: 0\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 0\n";
     });
 
     const result = await runQualitySweep(tmpDir, { sequential: true });
@@ -131,7 +134,7 @@ describe("runQualitySweep", () => {
 
   it("returns BLOCK when total warnings exceed threshold", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 2\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 2\n";
     });
 
     const result = await runQualitySweep(tmpDir, { warningThreshold: 5, sequential: true });
@@ -141,7 +144,7 @@ describe("runQualitySweep", () => {
 
   it("PASS at exactly warning threshold", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 1\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 1\n";
     });
 
     // 1 × 4 = 4, threshold = 5 → PASS
@@ -152,7 +155,7 @@ describe("runQualitySweep", () => {
 
   it("BLOCK at warning threshold + 1", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 2\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 2\n";
     });
 
     // 2 × 4 = 8 > 5 → BLOCK
@@ -172,7 +175,7 @@ describe("runQualitySweep", () => {
 
   it("saves individual reports to .framework/reports/", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 0\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 0\n";
     });
 
     await runQualitySweep(tmpDir, { sequential: true });
@@ -182,7 +185,7 @@ describe("runQualitySweep", () => {
 
   it("saves integrated report", async () => {
     restoreRunner = setValidatorRunner(async () => {
-      return "### Summary\n- Critical: 0\n- Warning: 0\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 0\n";
     });
 
     await runQualitySweep(tmpDir, { sequential: true });
@@ -194,7 +197,7 @@ describe("runQualitySweep", () => {
     const starts: number[] = [];
     restoreRunner = setValidatorRunner(async () => {
       starts.push(Date.now());
-      return "### Summary\n- Critical: 0\n- Warning: 0\n";
+      return "### Summary\n- Status: PASS\n- Critical: 0\n- Warning: 0\n";
     });
 
     await runQualitySweep(tmpDir); // parallel by default
@@ -256,5 +259,159 @@ describe("formatSweepOutput", () => {
     const output = formatSweepOutput(result);
     expect(output).toContain("BLOCK");
     expect(output).toContain("SEC-001");
+  });
+});
+
+// ─────────────────────────────────────────────
+// §6.1 Schema validation + retry (改修A)
+// ─────────────────────────────────────────────
+
+describe("validateOutputSchema", () => {
+  it("accepts valid schema", () => {
+    expect(
+      validateOutputSchema({ critical: 0, warning: 0, status: "PASS" }),
+    ).toBe(true);
+    expect(
+      validateOutputSchema({ critical: 3, warning: 1, status: "BLOCK" }),
+    ).toBe(true);
+  });
+
+  it("rejects invalid status value", () => {
+    expect(
+      validateOutputSchema({ critical: 0, warning: 0, status: "OK" }),
+    ).toBe(false);
+  });
+
+  it("rejects non-numeric critical/warning", () => {
+    expect(
+      validateOutputSchema({ critical: "0", warning: 0, status: "PASS" }),
+    ).toBe(false);
+    expect(
+      validateOutputSchema({ critical: 0, warning: null, status: "PASS" }),
+    ).toBe(false);
+  });
+
+  it("rejects null / non-object input", () => {
+    expect(validateOutputSchema(null)).toBe(false);
+    expect(validateOutputSchema("string")).toBe(false);
+    expect(validateOutputSchema(undefined)).toBe(false);
+  });
+});
+
+describe("parseValidatorOutputStrict", () => {
+  it("returns parsed object when all §6.1 fields present", () => {
+    const output = `### Summary
+- Status: PASS
+- Critical: 0
+- Warning: 2
+- Info: 1
+`;
+    const result = parseValidatorOutputStrict(output);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("PASS");
+    expect(result?.critical).toBe(0);
+    expect(result?.warning).toBe(2);
+  });
+
+  it("returns null when Status missing", () => {
+    const output = `### Summary
+- Critical: 0
+- Warning: 2
+`;
+    expect(parseValidatorOutputStrict(output)).toBeNull();
+  });
+
+  it("returns null for empty output", () => {
+    expect(parseValidatorOutputStrict("")).toBeNull();
+    expect(parseValidatorOutputStrict("   ")).toBeNull();
+  });
+});
+
+describe("runValidatorWithRetry", () => {
+  afterEach(() => {
+    // Ensure runner is restored even if test throws
+  });
+
+  it("succeeds on first attempt when output is valid", async () => {
+    const restore = setValidatorRunner(async () => `### Summary
+- Status: PASS
+- Critical: 0
+- Warning: 1
+`);
+    try {
+      const result = await runValidatorWithRetry(
+        { id: "x", name: "X", fullPrompt: "p" },
+        5000,
+      );
+      expect(result.attempts).toBe(1);
+      expect(result.parsed?.status).toBe("PASS");
+    } finally {
+      restore();
+    }
+  });
+
+  it("retries once and succeeds when first output is malformed", async () => {
+    let call = 0;
+    const restore = setValidatorRunner(async () => {
+      call++;
+      if (call === 1) return "garbage without schema";
+      return `### Summary
+- Status: BLOCK
+- Critical: 2
+- Warning: 0
+`;
+    });
+    try {
+      const result = await runValidatorWithRetry(
+        { id: "x", name: "X", fullPrompt: "p" },
+        5000,
+      );
+      expect(result.attempts).toBe(2);
+      expect(result.parsed?.status).toBe("BLOCK");
+      expect(result.parsed?.critical).toBe(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns parsed=null after 2 failed attempts", async () => {
+    const restore = setValidatorRunner(async () => "still garbage");
+    try {
+      const result = await runValidatorWithRetry(
+        { id: "x", name: "X", fullPrompt: "p" },
+        5000,
+      );
+      expect(result.attempts).toBe(2);
+      expect(result.parsed).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("runQualitySweep with schema validation", () => {
+  it("emits CRITICAL SCHEMA-001 finding when validator output invalid twice", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gate2-schema-"));
+    const contextDir = path.join(tmpDir, ".framework/gate-context");
+    fs.mkdirSync(contextDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(contextDir, "quality-sweep.md"),
+      "# Quality Sweep Context\n## Branch\ntest\n",
+    );
+    const restore = setValidatorRunner(async () => "unparseable output");
+    try {
+      const result = await runQualitySweep(tmpDir, {
+        sequential: true,
+        warningThreshold: 5,
+      });
+      expect(result.verdict).toBe("BLOCK");
+      const hasSchemaFinding = result.validators.some((v) =>
+        v.criticalFindings.some((f) => f.includes("SCHEMA-001")),
+      );
+      expect(hasSchemaFinding).toBe(true);
+    } finally {
+      restore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/lib/gate-quality-engine.ts
+++ b/src/cli/lib/gate-quality-engine.ts
@@ -4,9 +4,17 @@
  * ADR-016 Phase B-3: Run 4 validators in parallel,
  * parse results, auto-aggregate, and verdict.
  */
-import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import {
+  executeWithProvider,
+  getProvider,
+  loadProviderConfig,
+} from "./llm-provider.js";
+import {
+  checkTests,
+  formatTestQualityReport,
+} from "./test-quality-checker.js";
 
 // ─────────────────────────────────────────────
 // Types
@@ -44,6 +52,65 @@ export const VALIDATORS = [
 // ─────────────────────────────────────────────
 // Report Parser
 // ─────────────────────────────────────────────
+
+export interface ParsedValidatorOutput {
+  critical: number;
+  warning: number;
+  info: number;
+  criticalFindings: string[];
+  warningFindings: string[];
+  status?: "PASS" | "BLOCK";
+}
+
+/**
+ * Validate that a parsed validator output matches the schema from
+ * docs/specs/06_CODE_QUALITY.md §6.1 (監査レポートテンプレート):
+ *   - Status: PASS | BLOCK
+ *   - Critical: number
+ *   - Warning: number
+ */
+export function validateOutputSchema(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== "object") return false;
+  const p = parsed as Record<string, unknown>;
+  if (typeof p.critical !== "number") return false;
+  if (typeof p.warning !== "number") return false;
+  if (p.status !== "PASS" && p.status !== "BLOCK") return false;
+  return true;
+}
+
+/**
+ * Parse validator output. Returns null if schema validation fails
+ * (caller should retry with format instruction before giving up).
+ */
+export function parseValidatorOutputStrict(
+  output: string,
+): ParsedValidatorOutput | null {
+  if (!output || output.trim().length === 0) return null;
+
+  const critMatch = output.match(/[Cc]ritical:\s*(\d+)/);
+  const warnMatch = output.match(/[Ww]arning:\s*(\d+)/);
+  const infoMatch = output.match(/[Ii]nfo:\s*(\d+)/);
+  const statusMatch = output.match(/[Ss]tatus:\s*(PASS|BLOCK)/);
+
+  if (!critMatch || !warnMatch || !statusMatch) return null;
+
+  const critical = parseInt(critMatch[1], 10);
+  const warning = parseInt(warnMatch[1], 10);
+  const info = infoMatch ? parseInt(infoMatch[1], 10) : 0;
+  const status = statusMatch[1] as "PASS" | "BLOCK";
+
+  const parsed: ParsedValidatorOutput = {
+    critical,
+    warning,
+    info,
+    status,
+    criticalFindings: extractFindings(output, "CRITICAL"),
+    warningFindings: extractFindings(output, "WARNING"),
+  };
+
+  if (!validateOutputSchema(parsed)) return null;
+  return parsed;
+}
 
 export function parseValidatorOutput(output: string): {
   critical: number;
@@ -132,35 +199,12 @@ async function defaultRunner(
   prompt: string,
   timeoutMs: number,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // Each validator runs as an independent Claude session (Agent Teams mode).
-    // The validator can use Read/Grep tools to actively examine code.
-    const proc = spawn("claude", ["-p", prompt, "--allowedTools", "Read,Grep,Glob,Bash"], {
-      timeout: timeoutMs,
-      stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1",
-      },
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    proc.stdout.on("data", (data: Buffer) => { stdout += data.toString(); });
-    proc.stderr.on("data", (data: Buffer) => { stderr += data.toString(); });
-
-    proc.on("close", (code) => {
-      if (code === 0 || stdout.length > 0) {
-        resolve(stdout);
-      } else {
-        reject(new Error(`Validator exited with code ${code}: ${stderr.slice(0, 200)}`));
-      }
-    });
-
-    proc.on("error", (err) => {
-      reject(err);
-    });
+  const config = loadProviderConfig(process.cwd());
+  const provider = getProvider("validation", config);
+  return executeWithProvider(provider, prompt, {
+    allowedTools: ["Read", "Grep", "Glob", "Bash"],
+    experimentalAgentTeams: true,
+    timeoutMs,
   });
 }
 
@@ -191,7 +235,23 @@ export async function runQualitySweep(
   if (!fs.existsSync(contextPath)) {
     throw new Error("No quality sweep context found. Run 'framework gate quality' first to collect context.");
   }
-  const context = fs.readFileSync(contextPath, "utf-8");
+  let context = fs.readFileSync(contextPath, "utf-8");
+
+  // Deterministic test-quality pre-check (改修B).
+  // Results are appended to context so test-coverage-auditor can incorporate them.
+  try {
+    const testQualityResult = checkTests(projectDir);
+    const reportsDir = path.join(projectDir, ".framework/reports");
+    if (!fs.existsSync(reportsDir)) fs.mkdirSync(reportsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(reportsDir, "gate2-test-quality-deterministic.md"),
+      formatTestQualityReport(testQualityResult),
+      "utf-8",
+    );
+    context += `\n\n## Deterministic Test Quality Pre-check\n\n${formatTestQualityReport(testQualityResult)}\n`;
+  } catch {
+    // Pre-check is best-effort; failures should not block the sweep.
+  }
 
   // Read validator prompts
   const validatorPrompts = VALIDATORS.map((v) => {
@@ -298,19 +358,91 @@ ${context}
   return sweepResult;
 }
 
+/**
+ * Run validator with schema validation + one retry.
+ *
+ * Flow (per directive improvement A):
+ *   1. Initial run → parseValidatorOutputStrict → validateOutputSchema
+ *   2. If schema invalid → retry once with explicit §6.1 format instruction
+ *   3. If still invalid → emit CRITICAL "Validator output format invalid"
+ */
+export async function runValidatorWithRetry(
+  task: { id: string; name: string; fullPrompt: string },
+  timeoutMs: number,
+): Promise<{ output: string; parsed: ParsedValidatorOutput | null; attempts: number }> {
+  const output1 = await _runner(task.id, task.fullPrompt, timeoutMs);
+  const parsed1 = parseValidatorOutputStrict(output1);
+  if (parsed1) return { output: output1, parsed: parsed1, attempts: 1 };
+
+  const retryPrompt = `${task.fullPrompt}
+
+---
+
+**IMPORTANT: Output format requirement (§6.1 of 06_CODE_QUALITY)**
+
+Your previous response did not match the required schema. You MUST output EXACTLY the following section (case-sensitive keys):
+
+## ${task.name} Report
+
+### Summary
+- Status: PASS | BLOCK
+- Critical: <integer>
+- Warning: <integer>
+- Info: <integer>
+
+### Findings
+
+#### CRITICAL
+- [ID] description
+
+#### WARNING
+- [ID] description
+
+Status MUST be either "PASS" or "BLOCK". Critical and Warning MUST be integers.`;
+
+  const output2 = await _runner(task.id, retryPrompt, timeoutMs);
+  const parsed2 = parseValidatorOutputStrict(output2);
+  return {
+    output: `${output1}\n\n---\nRETRY OUTPUT:\n${output2}`,
+    parsed: parsed2,
+    attempts: 2,
+  };
+}
+
 async function executeValidator(
   task: { id: string; name: string; fullPrompt: string },
   timeoutMs: number,
 ): Promise<ValidatorResult> {
   const start = Date.now();
   try {
-    const output = await _runner(task.id, task.fullPrompt, timeoutMs);
-    const parsed = parseValidatorOutput(output);
+    const { output, parsed, attempts } = await runValidatorWithRetry(task, timeoutMs);
+
+    if (parsed) {
+      return {
+        name: task.name,
+        critical: parsed.critical,
+        warning: parsed.warning,
+        info: parsed.info,
+        criticalFindings: parsed.criticalFindings,
+        warningFindings: parsed.warningFindings,
+        rawOutput: output,
+        elapsedMs: Date.now() - start,
+      };
+    }
+
+    // Schema validation failed after retry → CRITICAL per directive
     return {
       name: task.name,
-      ...parsed,
+      critical: 1,
+      warning: 0,
+      info: 0,
+      criticalFindings: [
+        `[SCHEMA-001] Validator output format invalid after ${attempts} attempts (§6.1 schema violation: missing Status/Critical/Warning)`,
+      ],
+      warningFindings: [],
       rawOutput: output,
       elapsedMs: Date.now() - start,
+      error: "schema_validation_failed",
     };
   } catch (err) {
     return {

--- a/src/cli/lib/hooks-installer.ts
+++ b/src/cli/lib/hooks-installer.ts
@@ -4,6 +4,9 @@
  * Two enforcement layers:
  * 1. Claude Code hook (PreToolUse): Blocks src/ edits when gates not passed
  * 2. Git pre-commit hook: Blocks commits when gates not passed
+ *
+ * pre-commit-allow: console-log
+ * (this file generates hook scripts whose content contains literal console.log calls)
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/src/cli/lib/ingest-engine.ts
+++ b/src/cli/lib/ingest-engine.ts
@@ -14,7 +14,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { spawn, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   type IngestState,
   type IngestDocument,
@@ -126,38 +126,31 @@ async function defaultClaudeRunner(
   prompt: string,
   timeoutMs: number,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn("claude", ["-p", prompt, "--output-format", "json"], {
-      timeout: timeoutMs,
-      stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1",
-      },
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    proc.stdout.on("data", (data: Buffer) => { stdout += data.toString(); });
-    proc.stderr.on("data", (data: Buffer) => { stderr += data.toString(); });
-
-    proc.on("close", (code) => {
-      if (code === 0 || stdout.length > 0) {
-        // Extract the result text from JSON output format
-        try {
-          const parsed = JSON.parse(stdout) as { result?: string };
-          resolve(parsed.result ?? stdout);
-        } catch {
-          resolve(stdout);
-        }
-      } else {
-        reject(new Error(`Claude exited with code ${code}: ${stderr.slice(0, 500)}`));
-      }
-    });
-
-    proc.on("error", reject);
+  const { getProvider, loadProviderConfig, spawnProvider } = await import(
+    "./llm-provider.js"
+  );
+  const config = loadProviderConfig(process.cwd());
+  const provider = getProvider("ingestion", config);
+  const result = await spawnProvider(provider, prompt, {
+    outputFormat: "json",
+    experimentalAgentTeams: true,
+    timeoutMs,
   });
+  if (result.code !== 0 && result.stdout.length === 0) {
+    throw new Error(
+      `Provider "${provider.name}" exited with code ${result.code}: ${result.stderr.slice(0, 500)}`,
+    );
+  }
+  // Claude's --output-format json wraps result in {result: "..."}; codex doesn't.
+  if (provider.name === "claude") {
+    try {
+      const parsed = JSON.parse(result.stdout) as { result?: string };
+      return parsed.result ?? result.stdout;
+    } catch {
+      return result.stdout;
+    }
+  }
+  return result.stdout;
 }
 
 export function setClaudeRunner(runner: ClaudeRunner): () => void {

--- a/src/cli/lib/llm-provider.test.ts
+++ b/src/cli/lib/llm-provider.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  claudeProvider,
+  codexProvider,
+  getProvider,
+  loadProviderConfig,
+  autoDetectProvider,
+  providers,
+  registerProvider,
+  type LLMProvider,
+} from "./llm-provider.js";
+
+describe("llm-provider", () => {
+  it("claudeProvider builds args with -p and prompt", () => {
+    const args = claudeProvider.buildArgs("hello world");
+    expect(args).toEqual(["-p", "hello world"]);
+  });
+
+  it("claudeProvider builds args with allowedTools + output-format", () => {
+    const args = claudeProvider.buildArgs("prompt", {
+      allowedTools: ["Read", "Grep"],
+      outputFormat: "json",
+    });
+    expect(args).toEqual([
+      "-p",
+      "prompt",
+      "--allowedTools",
+      "Read,Grep",
+      "--output-format",
+      "json",
+    ]);
+  });
+
+  it("claudeProvider injects CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS when requested", () => {
+    const env = claudeProvider.buildEnv({ experimentalAgentTeams: true });
+    expect(env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe("1");
+  });
+
+  it("codexProvider uses exec --full-auto", () => {
+    const args = codexProvider.buildArgs("prompt");
+    expect(args).toEqual(["exec", "--full-auto", "prompt"]);
+  });
+
+  it("getProvider returns the default when role is 'default'", () => {
+    const config = { default: "claude" };
+    const provider = getProvider("default", config);
+    expect(provider.name).toBe("claude");
+  });
+
+  it("getProvider falls back to default when role has no override", () => {
+    const config = { default: "claude" };
+    const provider = getProvider("remediation", config);
+    expect(provider.name).toBe("claude");
+  });
+
+  it("getProvider uses role-specific override when set", () => {
+    const config = { default: "claude", validation: "codex" };
+    const provider = getProvider("validation", config);
+    expect(provider.name).toBe("codex");
+  });
+
+  it("getProvider throws on unknown provider", () => {
+    const config = { default: "nonexistent" };
+    expect(() => getProvider("default", config)).toThrow(/Unknown LLM provider/);
+  });
+
+  it("loadProviderConfig returns auto-detect when file missing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-"));
+    const config = loadProviderConfig(dir);
+    expect(typeof config.default).toBe("string");
+    expect(["claude", "codex"]).toContain(config.default);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loadProviderConfig reads provider section from config.json", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-"));
+    fs.mkdirSync(path.join(dir, ".framework"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".framework/config.json"),
+      JSON.stringify({
+        provider: { default: "codex", validation: "claude" },
+      }),
+    );
+    const config = loadProviderConfig(dir);
+    expect(config.default).toBe("codex");
+    expect(config.validation).toBe("claude");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("autoDetectProvider returns a known provider string", () => {
+    const name = autoDetectProvider();
+    expect(Object.keys(providers)).toContain(name);
+  });
+
+  it("registerProvider adds a new provider", () => {
+    const fake: LLMProvider = {
+      name: "fake-test",
+      command: "fake",
+      buildArgs: () => ["x"],
+      buildEnv: () => ({}),
+      isAvailable: () => true,
+    };
+    registerProvider(fake);
+    expect(providers["fake-test"]).toBe(fake);
+    delete providers["fake-test"];
+  });
+});

--- a/src/cli/lib/llm-provider.ts
+++ b/src/cli/lib/llm-provider.ts
@@ -1,0 +1,250 @@
+/**
+ * LLM Provider abstraction.
+ *
+ * Supports Claude Code and Codex CLI. Additional providers (Gemini, etc.)
+ * can be registered via the `providers` map.
+ *
+ * Configuration: `.framework/config.json` under the `provider` key.
+ * See docs/specs/06_CODE_QUALITY.md for the full spec proposal.
+ */
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface ProviderOptions {
+  allowedTools?: string[];
+  outputFormat?: "json" | "text";
+  experimentalAgentTeams?: boolean;
+  timeoutMs?: number;
+  cwd?: string;
+  extraEnv?: Record<string, string>;
+}
+
+export interface LLMProvider {
+  name: string;
+  command: string;
+  buildArgs(prompt: string, options?: ProviderOptions): string[];
+  buildEnv(options?: ProviderOptions): Record<string, string>;
+  isAvailable(): boolean;
+}
+
+export interface ProviderConfig {
+  default: string;
+  remediation?: string;
+  validation?: string;
+  ingestion?: string;
+  worktree?: string;
+}
+
+export type ProviderRole =
+  | "default"
+  | "remediation"
+  | "validation"
+  | "ingestion"
+  | "worktree";
+
+// ─────────────────────────────────────────────
+// Provider definitions
+// ─────────────────────────────────────────────
+
+function commandExists(command: string): boolean {
+  try {
+    execFileSync("which", [command], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const claudeProvider: LLMProvider = {
+  name: "claude",
+  command: "claude",
+  buildArgs(prompt, options) {
+    const args: string[] = ["-p", prompt];
+    if (options?.allowedTools && options.allowedTools.length > 0) {
+      args.push("--allowedTools", options.allowedTools.join(","));
+    }
+    if (options?.outputFormat === "json") {
+      args.push("--output-format", "json");
+    }
+    return args;
+  },
+  buildEnv(options) {
+    const env: Record<string, string> = {};
+    if (options?.experimentalAgentTeams) {
+      env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    }
+    return { ...env, ...(options?.extraEnv ?? {}) };
+  },
+  isAvailable() {
+    return commandExists("claude");
+  },
+};
+
+export const codexProvider: LLMProvider = {
+  name: "codex",
+  command: "codex",
+  buildArgs(prompt, _options) {
+    // Codex CLI: `codex exec --full-auto "<prompt>"`
+    // allowedTools / outputFormat are not directly mapped — rely on full-auto mode.
+    return ["exec", "--full-auto", prompt];
+  },
+  buildEnv(options) {
+    return { ...(options?.extraEnv ?? {}) };
+  },
+  isAvailable() {
+    return commandExists("codex");
+  },
+};
+
+export const providers: Record<string, LLMProvider> = {
+  claude: claudeProvider,
+  codex: codexProvider,
+};
+
+export function registerProvider(provider: LLMProvider): void {
+  providers[provider.name] = provider;
+}
+
+// ─────────────────────────────────────────────
+// Config loading
+// ─────────────────────────────────────────────
+
+export function loadProviderConfig(projectDir: string): ProviderConfig {
+  const configPath = path.join(projectDir, ".framework/config.json");
+  if (fs.existsSync(configPath)) {
+    try {
+      const raw = fs.readFileSync(configPath, "utf-8");
+      const parsed = JSON.parse(raw) as { provider?: Partial<ProviderConfig> };
+      if (parsed.provider && typeof parsed.provider.default === "string") {
+        return {
+          default: parsed.provider.default,
+          remediation: parsed.provider.remediation,
+          validation: parsed.provider.validation,
+          ingestion: parsed.provider.ingestion,
+          worktree: parsed.provider.worktree,
+        };
+      }
+    } catch {
+      // Fall through to auto-detect
+    }
+  }
+  return { default: autoDetectProvider() };
+}
+
+export function autoDetectProvider(): string {
+  if (claudeProvider.isAvailable()) return "claude";
+  if (codexProvider.isAvailable()) return "codex";
+  return "claude";
+}
+
+export function getProvider(
+  role: ProviderRole,
+  config: ProviderConfig,
+): LLMProvider {
+  const roleValue = role === "default" ? undefined : config[role];
+  const name = roleValue ?? config.default;
+  const provider = providers[name];
+  if (!provider) {
+    throw new Error(
+      `Unknown LLM provider: "${name}". Known: ${Object.keys(providers).join(", ")}`,
+    );
+  }
+  return provider;
+}
+
+// ─────────────────────────────────────────────
+// Execution
+// ─────────────────────────────────────────────
+
+export interface ExecuteResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+export async function executeWithProvider(
+  provider: LLMProvider,
+  prompt: string,
+  options: ProviderOptions = {},
+): Promise<string> {
+  const result = await spawnProvider(provider, prompt, options);
+  if (result.code === 0 || result.stdout.length > 0) {
+    return result.stdout;
+  }
+  throw new Error(
+    `Provider "${provider.name}" exited with code ${result.code}: ${result.stderr.slice(0, 500)}`,
+  );
+}
+
+/**
+ * Spawn a provider process and return the raw ChildProcess.
+ * Use this when the caller needs to manage lifecycle (PID tracking, kill, etc.).
+ */
+export function createProviderProcess(
+  provider: LLMProvider,
+  prompt: string,
+  options: ProviderOptions = {},
+): ChildProcess {
+  const args = provider.buildArgs(prompt, options);
+  const providerEnv = provider.buildEnv(options);
+  return spawn(provider.command, args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: options.cwd,
+    env: { ...process.env, ...providerEnv },
+  });
+}
+
+export function spawnProvider(
+  provider: LLMProvider,
+  prompt: string,
+  options: ProviderOptions = {},
+): Promise<ExecuteResult> {
+  return new Promise((resolve, reject) => {
+    const args = provider.buildArgs(prompt, options);
+    const providerEnv = provider.buildEnv(options);
+    const proc = spawn(provider.command, args, {
+      timeout: options.timeoutMs,
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: options.cwd,
+      env: { ...process.env, ...providerEnv },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      resolve({ stdout, stderr, code });
+    });
+
+    proc.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+// ─────────────────────────────────────────────
+// Testing hook
+// ─────────────────────────────────────────────
+
+/**
+ * Override the providers map for testing. Returns a restore function.
+ */
+export function setProviderForTesting(
+  name: string,
+  provider: LLMProvider,
+): () => void {
+  const prev = providers[name];
+  providers[name] = provider;
+  return () => {
+    if (prev === undefined) delete providers[name];
+    else providers[name] = prev;
+  };
+}

--- a/src/cli/lib/logger.ts
+++ b/src/cli/lib/logger.ts
@@ -13,13 +13,26 @@ function colorize(color: keyof typeof COLORS, text: string): string {
   return `${COLORS[color]}${text}${COLORS.reset}`;
 }
 
+// When structured output (e.g., --output json) is active, all informational
+// logs must go to stderr so stdout stays reserved for machine-readable output.
+let stdoutSink: NodeJS.WritableStream = process.stdout;
+
+/** Redirect human-readable logs to stderr. Returns a restore fn. */
+export function redirectInfoToStderr(): () => void {
+  const prev = stdoutSink;
+  stdoutSink = process.stderr;
+  return () => {
+    stdoutSink = prev;
+  };
+}
+
 export const logger = {
   info(message: string): void {
-    process.stdout.write(`${message}\n`);
+    stdoutSink.write(`${message}\n`);
   },
 
   success(message: string): void {
-    process.stdout.write(`${colorize("green", "+")} ${message}\n`);
+    stdoutSink.write(`${colorize("green", "+")} ${message}\n`);
   },
 
   warn(message: string): void {
@@ -33,22 +46,22 @@ export const logger = {
   },
 
   step(current: number, total: number, message: string): void {
-    process.stdout.write(
+    stdoutSink.write(
       `${colorize("dim", `[${current}/${total}]`)} ${message}\n`,
     );
   },
 
   header(message: string): void {
-    process.stdout.write(`\n${colorize("bold", message)}\n`);
+    stdoutSink.write(`\n${colorize("bold", message)}\n`);
   },
 
   dim(message: string): void {
-    process.stdout.write(`${colorize("dim", message)}\n`);
+    stdoutSink.write(`${colorize("dim", message)}\n`);
   },
 
   tree(lines: string[]): void {
     for (const line of lines) {
-      process.stdout.write(`  ${line}\n`);
+      stdoutSink.write(`  ${line}\n`);
     }
   },
 };

--- a/src/cli/lib/test-engine.test.ts
+++ b/src/cli/lib/test-engine.test.ts
@@ -1,3 +1,5 @@
+// pre-commit-allow: skip-only
+// (this file contains .skip patterns inside string fixtures for test engine testing)
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/src/cli/lib/test-model.test.ts
+++ b/src/cli/lib/test-model.test.ts
@@ -1,3 +1,5 @@
+// pre-commit-allow: skip-only
+// (this file contains .skip patterns inside string fixtures for test-model analysis)
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/src/cli/lib/test-quality-checker.test.ts
+++ b/src/cli/lib/test-quality-checker.test.ts
@@ -1,0 +1,202 @@
+// pre-commit-allow: skip-only
+// (this file contains .skip/.only patterns inside string fixtures that the checker detects)
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  analyzeTestFile,
+  evaluateTestQuality,
+  findTestFiles,
+  checkTests,
+  formatTestQualityReport,
+} from "./test-quality-checker.js";
+
+describe("analyzeTestFile", () => {
+  it("detects .skip as CRITICAL", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./foo.js";
+it.skip("bad", () => { expect(foo()).toBe(1); });`,
+    );
+    expect(r.hasSkipOrOnly).toBe(true);
+    expect(r.critical.some((c) => c.includes("TEST-SKIP"))).toBe(true);
+  });
+
+  it("detects .only as CRITICAL", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./foo.js";
+describe.only("bad", () => { it("x", () => { expect(foo()).toBe(1); }); });`,
+    );
+    expect(r.hasSkipOrOnly).toBe(true);
+  });
+
+  it("detects xdescribe as CRITICAL", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./foo.js";
+xdescribe("bad", () => { it("x", () => { expect(foo()).toBe(1); }); });`,
+    );
+    expect(r.hasSkipOrOnly).toBe(true);
+  });
+
+  it("detects empty it() body as CRITICAL", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./foo.js";
+it("empty", () => {});`,
+    );
+    expect(r.emptyDescribeBlocks).toBe(1);
+    expect(r.critical.some((c) => c.includes("TEST-EMPTY"))).toBe(true);
+  });
+
+  it("detects missing src import as WARNING", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { describe, it, expect } from "vitest";
+it("works", () => { expect(1).toBe(1); });`,
+    );
+    expect(r.importsSrc).toBe(false);
+    expect(r.warning.some((w) => w.includes("TEST-NO-SRC"))).toBe(true);
+  });
+
+  it("accepts file that imports from ./impl.js", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./impl.js";
+it("works", () => { expect(foo()).toBe(1); });`,
+    );
+    expect(r.importsSrc).toBe(true);
+  });
+
+  it("detects mock-only assertions as WARNING", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./impl.js";
+import { vi } from "vitest";
+it("mock", () => {
+  const mockFn = vi.fn();
+  foo(mockFn);
+  expect(mockFn).toHaveBeenCalled();
+});`,
+    );
+    expect(r.mockOnlyAssertions).toBe(true);
+    expect(r.warning.some((w) => w.includes("TEST-MOCK-ONLY"))).toBe(true);
+  });
+
+  it("counts expect() calls", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./impl.js";
+it("multi", () => {
+  expect(foo()).toBe(1);
+  expect(foo()).not.toBe(2);
+  expect(foo()).toBeDefined();
+});`,
+    );
+    expect(r.expectCount).toBe(3);
+  });
+
+  it("flags file with no expects as WARNING", () => {
+    const r = analyzeTestFile(
+      "x.test.ts",
+      `import { foo } from "./impl.js";
+it("nothing", () => { foo(); });`,
+    );
+    expect(r.expectCount).toBe(0);
+    expect(r.warning.some((w) => w.includes("TEST-NO-EXPECT"))).toBe(true);
+  });
+});
+
+describe("evaluateTestQuality", () => {
+  it("returns PASS with score 100 for clean reports", () => {
+    const reports = [
+      analyzeTestFile(
+        "a.test.ts",
+        `import { foo } from "./impl.js";
+it("x", () => { expect(foo()).toBe(1); });`,
+      ),
+    ];
+    const r = evaluateTestQuality(reports);
+    expect(r.verdict).toBe("PASS");
+    expect(r.score).toBe(100);
+  });
+
+  it("returns BLOCK when any CRITICAL finding", () => {
+    const reports = [
+      analyzeTestFile(
+        "a.test.ts",
+        `import { foo } from "./impl.js";
+it.skip("skipped", () => { expect(foo()).toBe(1); });`,
+      ),
+    ];
+    const r = evaluateTestQuality(reports);
+    expect(r.verdict).toBe("BLOCK");
+    expect(r.totalCritical).toBeGreaterThan(0);
+  });
+
+  it("clamps score to 0 minimum", () => {
+    const reports: ReturnType<typeof analyzeTestFile>[] = [];
+    for (let i = 0; i < 20; i++) {
+      reports.push(
+        analyzeTestFile(
+          `f${i}.test.ts`,
+          `import { foo } from "./impl.js";
+it.skip("s", () => { expect(foo()).toBe(1); });`,
+        ),
+      );
+    }
+    const r = evaluateTestQuality(reports);
+    expect(r.score).toBe(0);
+  });
+});
+
+describe("findTestFiles + checkTests", () => {
+  it("scans a directory and returns test quality result", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tqc-"));
+    fs.writeFileSync(
+      path.join(tmp, "good.test.ts"),
+      `import { foo } from "./foo.js";\nit("x", () => { expect(foo()).toBe(1); });`,
+    );
+    fs.writeFileSync(
+      path.join(tmp, "bad.test.ts"),
+      `import { foo } from "./foo.js";\nit.skip("x", () => { expect(foo()).toBe(1); });`,
+    );
+    const files = findTestFiles(tmp);
+    expect(files.length).toBe(2);
+    const result = checkTests(tmp);
+    expect(result.totalFiles).toBe(2);
+    expect(result.verdict).toBe("BLOCK");
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("ignores node_modules and dist", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tqc-"));
+    fs.mkdirSync(path.join(tmp, "node_modules"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "node_modules", "x.test.ts"),
+      `it.skip("x", () => {});`,
+    );
+    const files = findTestFiles(tmp);
+    expect(files).toHaveLength(0);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe("formatTestQualityReport", () => {
+  it("produces a markdown report", () => {
+    const reports = [
+      analyzeTestFile(
+        "a.test.ts",
+        `import { foo } from "./impl.js";
+it("x", () => { expect(foo()).toBe(1); });`,
+      ),
+    ];
+    const result = evaluateTestQuality(reports);
+    const md = formatTestQualityReport(result);
+    expect(md).toContain("Test Quality Report");
+    expect(md).toContain("Score: 100/100");
+    expect(md).toContain("PASS");
+  });
+});

--- a/src/cli/lib/test-quality-checker.ts
+++ b/src/cli/lib/test-quality-checker.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic test-quality checker.
+ *
+ * Regex-based detection of "fake tests" — tests that don't actually
+ * exercise the implementation. Based on §3.3/§3.4 of
+ * docs/specs/06_CODE_QUALITY.md.
+ *
+ * Scoring is aligned with §3.5 テスト品質スコアカード (100-pt scale).
+ *
+ * Detection patterns:
+ *   - Tests that don't import from src/    → not verifying implementation
+ *   - Only expect(mockFn).toHaveBeenCalled  → violates §3.4 "モック最小限"
+ *   - Empty `it('...', () => {})`           → empty tests
+ *   - `.skip` / `.only`                     → forbidden in main branch
+ *
+ * This is a lightweight pre-check to feed into Gate 2 (test-coverage-auditor).
+ * Not a replacement for AST-based analysis (v1.1).
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+export interface TestFileReport {
+  file: string;
+  expectCount: number;
+  importsSrc: boolean;
+  hasSkipOrOnly: boolean;
+  mockOnlyAssertions: boolean;
+  emptyDescribeBlocks: number;
+  critical: string[];
+  warning: string[];
+}
+
+export interface TestQualityResult {
+  files: TestFileReport[];
+  totalFiles: number;
+  totalCritical: number;
+  totalWarning: number;
+  score: number;
+  verdict: "PASS" | "BLOCK";
+  findings: Array<{ file: string; severity: "CRITICAL" | "WARNING"; message: string }>;
+}
+
+// ─────────────────────────────────────────────
+// File analysis
+// ─────────────────────────────────────────────
+
+export function analyzeTestFile(filePath: string, content: string): TestFileReport {
+  const critical: string[] = [];
+  const warning: string[] = [];
+
+  // Strip block comments so comment-only mentions of forbidden tokens don't trigger.
+  const code = content.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // expect() count (all forms)
+  const expectMatches = code.match(/\bexpect\s*\(/g);
+  const expectCount = expectMatches ? expectMatches.length : 0;
+
+  // Imports from src/
+  const importsSrc =
+    /from\s+['"][^'"]*\/src\/[^'"]*['"]/.test(code) ||
+    /from\s+['"]\.\.?\/[^'"]*src[^'"]*['"]/.test(code) ||
+    // sibling .js imports (e.g. "./llm-provider.js") count as importing implementation
+    /from\s+['"]\.\/[^'"]+\.(js|ts)['"]/.test(code) ||
+    /from\s+['"]\.\.\/[^'"]+\.(js|ts)['"]/.test(code);
+
+  // .skip / .only
+  const skipOnlyMatches =
+    code.match(/\b(describe|it|test)\.(skip|only)\s*\(/g) ||
+    code.match(/\b(xdescribe|xit|xtest)\s*\(/g);
+  const hasSkipOrOnly = !!skipOnlyMatches && skipOnlyMatches.length > 0;
+  if (hasSkipOrOnly) {
+    critical.push(
+      `[TEST-SKIP] Forbidden .skip/.only/xdescribe/xit found (§3.4 禁止)`,
+    );
+  }
+
+  // Empty test bodies: it('...', () => {}) — matches zero-body arrow functions.
+  const emptyBlocks =
+    code.match(/\b(it|test)\s*\(\s*['"`][^'"`]*['"`]\s*,\s*(?:async\s*)?\(\s*\)\s*=>\s*\{\s*\}\s*\)/g) ||
+    [];
+  const emptyDescribeBlocks = emptyBlocks.length;
+  if (emptyDescribeBlocks > 0) {
+    critical.push(`[TEST-EMPTY] ${emptyDescribeBlocks} empty test block(s) found`);
+  }
+
+  // Mock-only assertions: expect(mock*) called but no other expect patterns.
+  const mockAssertPatterns =
+    code.match(/expect\s*\(\s*(mock|spy|stub|vi\.fn|jest\.fn)[A-Za-z_]*\s*\)/gi) ||
+    [];
+  const totalExpects = expectCount;
+  const mockAssertions = mockAssertPatterns.length;
+  const mockOnlyAssertions =
+    totalExpects > 0 && mockAssertions > 0 && mockAssertions === totalExpects;
+  if (mockOnlyAssertions) {
+    warning.push(
+      `[TEST-MOCK-ONLY] All ${totalExpects} expect()s target mocks — violates §3.4 "モックは最小限"`,
+    );
+  }
+
+  // No src/ import → possibly fake test
+  if (!importsSrc && expectCount > 0) {
+    warning.push(
+      `[TEST-NO-SRC] Test file has ${expectCount} expect()s but no imports from implementation (src/)`,
+    );
+  }
+
+  // Zero expects: pure scaffolding
+  if (expectCount === 0) {
+    warning.push(`[TEST-NO-EXPECT] File has no expect() calls`);
+  }
+
+  return {
+    file: filePath,
+    expectCount,
+    importsSrc,
+    hasSkipOrOnly,
+    mockOnlyAssertions,
+    emptyDescribeBlocks,
+    critical,
+    warning,
+  };
+}
+
+// ─────────────────────────────────────────────
+// Aggregation + scoring
+// ─────────────────────────────────────────────
+
+/**
+ * Score against §3.5 category #6 (テスト品質 = 10pt).
+ * Start at 100, deduct for each CRITICAL/WARNING finding.
+ * This is a §3.5-style deterministic pre-check; full scoring is done by
+ * the test-coverage-auditor LLM.
+ */
+export function evaluateTestQuality(reports: TestFileReport[]): TestQualityResult {
+  const findings: TestQualityResult["findings"] = [];
+  let score = 100;
+  let totalCritical = 0;
+  let totalWarning = 0;
+
+  for (const r of reports) {
+    for (const c of r.critical) {
+      findings.push({ file: r.file, severity: "CRITICAL", message: c });
+      totalCritical++;
+      score -= 10;
+    }
+    for (const w of r.warning) {
+      findings.push({ file: r.file, severity: "WARNING", message: w });
+      totalWarning++;
+      score -= 2;
+    }
+  }
+
+  if (score < 0) score = 0;
+  const verdict: "PASS" | "BLOCK" = totalCritical > 0 ? "BLOCK" : "PASS";
+
+  return {
+    files: reports,
+    totalFiles: reports.length,
+    totalCritical,
+    totalWarning,
+    score,
+    verdict,
+    findings,
+  };
+}
+
+// ─────────────────────────────────────────────
+// Directory scanning
+// ─────────────────────────────────────────────
+
+export function findTestFiles(rootDir: string): string[] {
+  const results: string[] = [];
+  const ignore = new Set(["node_modules", "dist", ".next", "coverage", ".git"]);
+
+  function walk(dir: string) {
+    if (!fs.existsSync(dir)) return;
+    for (const name of fs.readdirSync(dir)) {
+      if (ignore.has(name)) continue;
+      const fp = path.join(dir, name);
+      const stat = fs.statSync(fp);
+      if (stat.isDirectory()) {
+        walk(fp);
+      } else if (/\.(test|spec)\.(ts|tsx|js|jsx|mts|cts)$/.test(name)) {
+        results.push(fp);
+      }
+    }
+  }
+  walk(rootDir);
+  return results;
+}
+
+export function checkTests(projectDir: string): TestQualityResult {
+  const files = findTestFiles(projectDir);
+  const reports: TestFileReport[] = [];
+  for (const f of files) {
+    const content = fs.readFileSync(f, "utf-8");
+    reports.push(analyzeTestFile(path.relative(projectDir, f), content));
+  }
+  return evaluateTestQuality(reports);
+}
+
+// ─────────────────────────────────────────────
+// Human-readable formatting
+// ─────────────────────────────────────────────
+
+export function formatTestQualityReport(result: TestQualityResult): string {
+  const lines: string[] = [];
+  lines.push(`# Test Quality Report (Deterministic Pre-check)`);
+  lines.push("");
+  lines.push(`- Files scanned: ${result.totalFiles}`);
+  lines.push(`- CRITICAL: ${result.totalCritical}`);
+  lines.push(`- WARNING: ${result.totalWarning}`);
+  lines.push(`- Score: ${result.score}/100`);
+  lines.push(`- Verdict: **${result.verdict}**`);
+  lines.push("");
+  if (result.findings.length > 0) {
+    lines.push("## Findings");
+    lines.push("");
+    for (const f of result.findings) {
+      lines.push(`- [${f.severity}] ${f.file}: ${f.message}`);
+    }
+  } else {
+    lines.push("No findings.");
+  }
+  return lines.join("\n");
+}

--- a/src/cli/lib/worktree-manager.ts
+++ b/src/cli/lib/worktree-manager.ts
@@ -6,7 +6,12 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { execSync, type ChildProcess } from "node:child_process";
+import {
+  createProviderProcess,
+  getProvider,
+  loadProviderConfig,
+} from "./llm-provider.js";
 
 // ─────────────────────────────────────────────
 // Types
@@ -437,15 +442,11 @@ async function runTaskInWorktree(
   const prompt = `Implement task: ${session.taskId}. Follow the implementation plan in .framework/plan.json. Run tests after implementation.`;
 
   return new Promise<void>((resolve, reject) => {
-    const child: ChildProcess = spawn(
-      "claude",
-      ["-p", prompt],
-      {
-        cwd: session.worktreePath,
-        stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env },
-      },
-    );
+    const providerConfig = loadProviderConfig(session.worktreePath);
+    const provider = getProvider("worktree", providerConfig);
+    const child: ChildProcess = createProviderProcess(provider, prompt, {
+      cwd: session.worktreePath,
+    });
 
     session.pid = child.pid;
     let timedOut = false;

--- a/templates/project/.framework/config.json
+++ b/templates/project/.framework/config.json
@@ -1,0 +1,9 @@
+{
+  "provider": {
+    "default": "claude",
+    "remediation": "claude",
+    "validation": "claude",
+    "ingestion": "claude",
+    "worktree": "claude"
+  }
+}

--- a/templates/project/.husky/pre-commit
+++ b/templates/project/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Pre-commit hook for ai-dev-framework.
+#
+# Runs docs/specs/06_CODE_QUALITY.md §1.3/§3.4/§4.4 content-level checks.
+# Bypass (not recommended): git commit --no-verify
+#
+bash "$(git rev-parse --show-toplevel)/scripts/pre-commit-checks.sh"

--- a/templates/project/scripts/pre-commit-checks.sh
+++ b/templates/project/scripts/pre-commit-checks.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Pre-commit content-level checks based on docs/specs/06_CODE_QUALITY.md:
+#   §1.3 #8 (完全性):   no console.log in production source (non-test)
+#   §3.4 (作成原則):     no .skip / .only in test files
+#   §1.3 #4 (セキュリティ): hardcoded secret detection
+#   §4.4 (CI合格条件):   front-load a subset of required CI checks
+#
+# Escape hatches (place in the file as a comment):
+#   // pre-commit-allow: console-log    — file may contain console.log
+#                                         (e.g., hook-script generators)
+#   // pre-commit-allow: skip-only      — file may contain .skip/.only inside
+#                                         string fixtures demonstrating them
+#   // pre-commit-allow: secret         — file may contain hardcoded test tokens
+#
+# Per-line escape:
+#   // allowed                          — single-line exemption for console.log
+#
+# Bypass entire script: git commit --no-verify (NOT recommended)
+#
+set -e
+ERRORS=0
+
+say() { printf "%s\n" "$*"; }
+
+# file_has_allow <file> <token>  — returns 0 if file opts out of the named check.
+file_has_allow() {
+  grep -q "pre-commit-allow: $2" "$1" 2>/dev/null
+}
+
+# ─────────────────────────────────────────────
+# §1.3 #8 完全性: console.log detection (production src only)
+# ─────────────────────────────────────────────
+CONSOLE_LOGS_ALL=$(grep -rEln "(^|\s|;|\{)console\.log\s*\(" \
+  --include="*.ts" --include="*.tsx" src/ 2>/dev/null || true)
+CONSOLE_ERRORS=""
+for f in $CONSOLE_LOGS_ALL; do
+  case "$f" in
+    *.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx) continue ;;
+  esac
+  if file_has_allow "$f" "console-log"; then continue; fi
+  hits=$(grep -En "(^|\s|;|\{)console\.log\s*\(" "$f" | grep -v "// allowed" || true)
+  if [ -n "$hits" ]; then
+    CONSOLE_ERRORS="${CONSOLE_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$CONSOLE_ERRORS" ]; then
+  say ""
+  say "ERROR: console.log found (docs/specs/06_CODE_QUALITY.md §1.3 #8 完全性 violation):"
+  printf "%b" "$CONSOLE_ERRORS"
+  say ""
+  say "  Fix: remove console.log from production code, append '// allowed' to a single"
+  say "       line, or add '// pre-commit-allow: console-log' to the file if it"
+  say "       intentionally generates scripts containing console.log."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# §3.4 テスト作成原則: .skip / .only / xdescribe
+# ─────────────────────────────────────────────
+SKIP_FILES=$(grep -rEln "(describe|it|test)\.(skip|only)\s*\(|\b(xdescribe|xit|xtest)\s*\(" \
+  --include="*.test.ts" --include="*.test.tsx" --include="*.spec.ts" --include="*.spec.tsx" \
+  . 2>/dev/null | grep -v node_modules | grep -v dist || true)
+SKIP_ERRORS=""
+for f in $SKIP_FILES; do
+  if file_has_allow "$f" "skip-only"; then continue; fi
+  hits=$(grep -En "(describe|it|test)\.(skip|only)\s*\(|\b(xdescribe|xit|xtest)\s*\(" "$f" || true)
+  if [ -n "$hits" ]; then
+    SKIP_ERRORS="${SKIP_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$SKIP_ERRORS" ]; then
+  say ""
+  say "ERROR: .skip / .only / xdescribe found in tests (docs/specs/06_CODE_QUALITY.md §3.4 violation):"
+  printf "%b" "$SKIP_ERRORS"
+  say ""
+  say "  Fix: remove .skip/.only. Skipped tests are forbidden in the main branch."
+  say "       For files containing string fixtures demonstrating the pattern,"
+  say "       add '// pre-commit-allow: skip-only' to the file."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# §1.3 #4 セキュリティ: hardcoded secret detection
+# ─────────────────────────────────────────────
+SECRET_FILES=$(grep -rEln "(sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|ghp_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,})" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" src/ 2>/dev/null || true)
+SECRET_ERRORS=""
+for f in $SECRET_FILES; do
+  if file_has_allow "$f" "secret"; then continue; fi
+  hits=$(grep -En "(sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|ghp_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,})" "$f" | grep -v "// allowed-secret" || true)
+  if [ -n "$hits" ]; then
+    SECRET_ERRORS="${SECRET_ERRORS}${f}:\n${hits}\n"
+  fi
+done
+if [ -n "$SECRET_ERRORS" ]; then
+  say ""
+  say "ERROR: potential hardcoded secret (docs/specs/06_CODE_QUALITY.md §1.3 #4 セキュリティ violation):"
+  printf "%b" "$SECRET_ERRORS"
+  say ""
+  say "  Fix: move to environment variable, append '// allowed-secret' per line,"
+  say "       or add '// pre-commit-allow: secret' to the file if it contains test fixtures."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ─────────────────────────────────────────────
+# Verdict
+# ─────────────────────────────────────────────
+if [ $ERRORS -gt 0 ]; then
+  say ""
+  say "Pre-commit checks failed ($ERRORS errors). See docs/specs/06_CODE_QUALITY.md."
+  say "Emergency bypass (not recommended): git commit --no-verify"
+  exit 1
+fi
+
+say "OK Pre-commit content checks passed"
+exit 0


### PR DESCRIPTION
## Summary

OSS公開前の5改修 (A-E) を1つのPRにまとめて実装。決定論的な制御点を追加し、LLM出力の非決定性に依存しない検証を強化する。**CEOのscope判断 (2026-04-13, option C)** により、auditor 6 axes レビューの CRITICAL 指摘のみ cycle 2 で対応、残りは follow-up PR 群で処理する方針。

## 改修内容

- **A**: Validator出力スキーマ検証+リトライ（JSON schema は新規定義として追記提案、§6.1 は Markdown template のためフォーマット指針としてのみ参照）
- **B**: 偽テスト機械検出（正規表現ベース、`framework check tests` CLI、Gate 2 連携）— import 判定精度は follow-up PR で向上予定
- **C**: pre-commitフック基本セット（console.log / .skip/.only / 秘密情報検出）
- **D**: LLMプロバイダー抽象化（Claude Code + Codex対応、`.framework/config.json` で切替）
- **E**: Gate結果構造化出力（`--output json`、stdout=JSON / stderr=log）
  - **cycle 2 fix**: `gate release --output json` の fake `verdict:"SHIP"` を除去、新 `GateContextJSON` 型で context-collection phase を表現（verdict フィールドを持たない honest-by-construction）

## テスト結果

- ベースライン: 1414 passed / 6 failed（main時点、feedback-engine timeouts 等）
- cycle 1: 1458 passed (+44 新規テスト、既存 6 失敗は不変)
- cycle 2: **1461 passed** (+3 新規テスト: GateContextJSON の verdict 不在検証)
- 新 regression: **追加改修コードパスには検出なし**。既存 5-6 失敗は pre-existing timeout（feedback-engine / auto-feedback）で本PRと無関係、`adf-dev-state.md` で別件追跡
- 未カバー領域（follow-up PR で対応予定）: `--output json` contract の CLI レベル契約テスト / gate release honesty の E2E / alias import path / `.worktrees` 除外

## 依存関係

**前提**: [PR #53](https://github.com/watchout/ai-dev-framework/pull/53)（CI pre-existing failure 修復）がマージされ main が CI green になった後、本PRを rebase して CI 再実行する。現在の CI 赤は PR #53 未マージによる pre-existing 影響。

## auditor / CTO レビュー経緯

| 観点 | cycle 1 | cycle 2 |
|---|---|---|
| 正直さ (fake SHIP verdict) | 🔴 BLOCK | ✅ 修正済 (GateContextJSON) |
| SSOT 参照 (§6.1) | 🔴 BLOCK | 🟡 follow-up PR で正確化予定 (本PR body で訂正済) |
| 改修B 判定精度 | 🔴 BLOCK | 🟡 follow-up PR 予定 |
| PR body 正直性 | 🔴 BLOCK | ✅ 本 body で正確化 |
| scope bundle | 🟡 太い | ⚪ CEO option C 判断で維持 |
| `.worktrees` 除外 | 🟡 | 🟡 follow-up PR 予定 |

## SSOT 参照

gdrive の `IYASAKA/開発/ADF/v1.0.0_2026-04-12/specs/` を正とし、二重管理回避のためローカルに複製せず。rclone cat で参照。

- A/B/C/E: `06_CODE_QUALITY_v1.0.0.md`（§6.1 は監査レポート Markdown template、JSON schema は本PR + follow-up で新規定義として spec 追記提案）
- D: `07_AI_PROTOCOL_v1.0.0.md` + 追記提案 `docs/proposals/spec-addition-06-llm-provider.md`

## Test plan

- [x] ローカル `npm test`: 1461 passed / 5 failed (pre-existing timeouts)
- [x] 新規 CRITICAL 指摘（fake SHIP）の修正: `gate-json-output.test.ts` で verdict フィールド不在を検証
- [ ] PR #53 merge 後に本PR rebase + CI 再実行で全 green 確認
- [ ] auditor 再 review（cycle 2 CRITICAL 修正確認）
- [ ] CTO 三次レビュー
- [ ] follow-up PR 群の起票（SSOT参照正確化 / 改修B精度向上 / .worktrees除外 / regression テスト拡充）

## Route label

`route:fast-merge`（framework CLI 機能追加、DB schema / 公開API / 新規 package.json 依存なし。Codex CLI は実行時依存でユーザ任意）

## Follow-up PRs（本PRマージ後に順次起票）

1. fix: 改修A/E の SSOT 参照正確化（06_CODE_QUALITY.md に JSON schema 章を新規追記）
2. fix: 改修B test-quality-checker の import 判定精度向上（alias / package export / helper対応）
3. fix: `.worktrees` 除外（Gate 2 への混入防止）
4. test: `--output json` contract / gate release honesty / alias import の回帰テスト追加
5. feat: `feature/gate-a-profiles` — 5 プロファイル対応 + governance-flow.md profile 定義セクション追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)