### PR TITLE
fix(ci): resolve pre-existing CI failures (TS errors, audit, worktree test)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,9 +1482,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT",
       "optional": true
     },
@@ -1499,9 +1499,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -1531,9 +1531,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1547,9 +1547,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3141,9 +3141,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4364,9 +4364,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5575,15 +5575,15 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5595,15 +5595,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5892,9 +5892,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6760,9 +6760,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7093,9 +7093,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7186,9 +7186,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7306,9 +7306,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/cli/lib/run-model.test.ts
+++ b/src/cli/lib/run-model.test.ts
@@ -408,13 +408,15 @@ describe("saveRunState atomic write", () => {
     state.tasks.push({
       taskId: "TEST-001",
       featureId: "FEAT-001",
+      taskKind: "test",
       name: "Test task",
       seq: "1.1",
       status: "in_progress",
       blockedBy: [],
+      files: [],
       startedAt: new Date().toISOString(),
       heartbeatAt: new Date().toISOString(),
-    } as TaskExecution);
+    });
     saveRunState(tmpDir, state);
 
     const loaded = loadRunState(tmpDir);

--- a/src/cli/lib/sync-engine.test.ts
+++ b/src/cli/lib/sync-engine.test.ts
@@ -155,7 +155,7 @@ describe("runSync", () => {
 
     // Mock github-engine
     const ghEngine = await import("./github-engine.js");
-    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockReturnValue(true);
+    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockResolvedValue(true);
     const syncSpy = vi.spyOn(ghEngine, "syncStatusFromGitHub").mockResolvedValue({
       updated: 1,
       issues: [{ taskId: "F001-T001", issueNumber: 1, status: "closed", labels: [] }],
@@ -181,7 +181,7 @@ describe("runSync", () => {
     atomicWritePlan(dir, makePlan());
 
     const ghEngine = await import("./github-engine.js");
-    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockReturnValue(false);
+    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockResolvedValue(false);
 
     try {
       const result = await runSync({ projectDir: dir });
@@ -219,7 +219,7 @@ describe("runSync", () => {
     );
 
     const ghEngine = await import("./github-engine.js");
-    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockReturnValue(true);
+    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockResolvedValue(true);
     const syncSpy = vi.spyOn(ghEngine, "syncStatusFromGitHub").mockResolvedValue({
       updated: 1,
       issues: [{ taskId: "F001-T001", issueNumber: 1, status: "open", labels: [] }],
@@ -245,7 +245,7 @@ describe("runSync", () => {
     atomicWritePlan(dir, makePlan());
 
     const ghEngine = await import("./github-engine.js");
-    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockReturnValue(true);
+    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockResolvedValue(true);
     const syncSpy = vi.spyOn(ghEngine, "syncStatusFromGitHub").mockResolvedValue({
       updated: 0,
       issues: [],
@@ -267,7 +267,7 @@ describe("runSync", () => {
     atomicWritePlan(dir, makePlan());
 
     const ghEngine = await import("./github-engine.js");
-    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockReturnValue(true);
+    const isGhSpy = vi.spyOn(ghEngine, "isGhAvailable").mockResolvedValue(true);
     const syncSpy = vi.spyOn(ghEngine, "syncStatusFromGitHub").mockRejectedValue(
       new Error("network timeout"),
     );

--- a/src/cli/lib/sync-engine.ts
+++ b/src/cli/lib/sync-engine.ts
@@ -256,7 +256,7 @@ export async function runSync(options: SyncOptions): Promise<SyncEngineResult> {
 
     // Pull live status from GitHub and update run-state
     let updated = 0;
-    if (isGhAvailable()) {
+    if (await isGhAvailable()) {
       try {
         const statusResult = await syncStatusFromGitHub(projectDir);
         if (statusResult.errors.length > 0) {

--- a/src/cli/lib/worktree-manager.test.ts
+++ b/src/cli/lib/worktree-manager.test.ts
@@ -22,11 +22,24 @@ import {
 
 function createTestRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fw-wt-test-"));
-  execSync("git init", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  // Force initial branch name to "main" regardless of the host git config.
+  // Older git versions don't support -b on init, so we fall back to renaming.
+  try {
+    execSync("git init -b main", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  } catch {
+    execSync("git init", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  }
   execSync("git config user.email 'test@test.com'", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
   execSync("git config user.name 'Test'", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
   fs.writeFileSync(path.join(dir, "README.md"), "# Test", "utf-8");
   execSync("git add . && git commit -m 'init'", { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  // After the first commit, if HEAD is not on "main", rename it so tests
+  // that reference "main" as the base branch succeed on CI hosts where
+  // git defaults to "master".
+  const current = execSync("git branch --show-current", { cwd: dir, encoding: "utf-8" }).trim();
+  if (current && current !== "main") {
+    execSync(`git branch -m ${current} main`, { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  }
   return dir;
 }
 

--- a/src/lib/prompt-manager/api.ts
+++ b/src/lib/prompt-manager/api.ts
@@ -16,8 +16,8 @@ import {
   CreatePromptRequest,
   UpdatePromptRequest,
   RenderRequest,
-} from './types';
-import { PromptManager } from './manager';
+} from './types.js';
+import { PromptManager } from './manager.js';
 
 export function createPromptRouter(manager: PromptManager): any {
   // ExpressRouter の作成（実装時は express.Router()）

--- a/src/lib/prompt-manager/index.ts
+++ b/src/lib/prompt-manager/index.ts
@@ -3,10 +3,10 @@
  * CRUD、変数埋め込み、バージョン管理、API実装
  */
 
-export { PromptManager } from './manager';
-export { PromptRenderer } from './renderer';
-export { InMemoryStorage, type StorageAdapter } from './storage';
-export { createPromptRouter } from './api';
+export { PromptManager } from './manager.js';
+export { PromptRenderer } from './renderer.js';
+export { InMemoryStorage, type StorageAdapter } from './storage.js';
+export { createPromptRouter } from './api.js';
 export type {
   PromptTemplate,
   Variable,
@@ -20,4 +20,4 @@ export type {
   ApiErrorResponse,
   ValidationResult,
   ValidationError,
-} from './types';
+} from './types.js';

--- a/src/lib/prompt-manager/manager.ts
+++ b/src/lib/prompt-manager/manager.ts
@@ -11,9 +11,9 @@ import {
   RenderRequest,
   RenderResult,
   VersionInfo,
-} from './types';
-import { StorageAdapter, InMemoryStorage } from './storage';
-import { PromptRenderer } from './renderer';
+} from './types.js';
+import { StorageAdapter, InMemoryStorage } from './storage.js';
+import { PromptRenderer } from './renderer.js';
 
 export class PromptManager {
   private storage: StorageAdapter;
@@ -35,7 +35,7 @@ export class PromptManager {
     const variables =
       request.variables.length > 0
         ? request.variables
-        : extractedVariables.map((name) => ({
+        : extractedVariables.map((name: string) => ({
             name,
             type: 'string' as const,
             description: `Auto-extracted variable: ${name}`,
@@ -135,7 +135,7 @@ export class PromptManager {
    */
   async rollback(id: string, version: string, rolledBackBy: string): Promise<PromptTemplate> {
     const versionInfo = (await this.storage.getVersions(id)).find(
-      (v) => v.version === version,
+      (v: VersionInfo) => v.version === version,
     );
     if (!versionInfo) {
       throw new Error(`Version ${version} not found`);

--- a/src/lib/prompt-manager/renderer.ts
+++ b/src/lib/prompt-manager/renderer.ts
@@ -2,7 +2,7 @@
  * プロンプト変数埋め込みエンジン
  */
 
-import { Variable, RenderRequest, RenderResult, ValidationResult, ValidationError } from './types';
+import { Variable, RenderRequest, RenderResult, ValidationResult, ValidationError } from './types.js';
 
 export class PromptRenderer {
   /**
@@ -16,7 +16,7 @@ export class PromptRenderer {
     // バリデーション
     const validation = this.validateVariables(variables, templateVariables);
     if (!validation.valid) {
-      throw new Error(`Variable validation failed: ${validation.errors.map((e) => e.message).join(', ')}`);
+      throw new Error(`Variable validation failed: ${validation.errors.map((e: ValidationError) => e.message).join(', ')}`);
     }
 
     let rendered = content;

--- a/src/lib/prompt-manager/storage.ts
+++ b/src/lib/prompt-manager/storage.ts
@@ -2,7 +2,7 @@
  * プロンプトテンプレートストレージレイヤー
  */
 
-import { PromptTemplate, VersionInfo, PromptFilter } from './types';
+import { PromptTemplate, VersionInfo, PromptFilter } from './types.js';
 
 export interface StorageAdapter {
   create(template: PromptTemplate): Promise<PromptTemplate>;
@@ -83,7 +83,7 @@ export class InMemoryStorage implements StorageAdapter {
       }
       if (filter.tags && filter.tags.length > 0) {
         templates = templates.filter((t) =>
-          filter.tags!.some((tag) => t.tags.includes(tag)),
+          filter.tags!.some((tag: string) => t.tags.includes(tag)),
         );
       }
       if (filter.category) {


### PR DESCRIPTION
## Summary

CIが暫く全PRで赤状態だった4件の pre-existing issue を修復。これがマージされると後続の feature branch（PR #52 OSS-prep 等）が CI green を達成可能に。

## 修復内容

1. **TypeScript errors** (`src/lib/prompt-manager/*`)
   - Relative imports に `.js` 拡張子追加（tsconfig.cli.json の moduleResolution: node16 対応）
   - 3箇所の implicit `any` に明示的な型付与

2. **sync-engine.ts:259**
   - `if (isGhAvailable())` が Promise<boolean> の truthy 判定で常にtrueだった → `await` 追加

3. **worktree-manager.test.ts**
   - `createTestRepo()` の `git init` が CI の git で `master` 初期化されるため、テスト内の `git worktree add ... "main"` が失敗。`git init -b main` + 旧git向けrename fallback に変更

4. **Next.js Type Check (full-root tsc) 修正 (2nd commit)**
   - `sync-engine.test.ts` の `isGhAvailable` mock を `mockResolvedValue` に（Promise<boolean> 対応）
   - `run-model.test.ts:408` の TaskExecution cast で欠落していた `taskKind` / `files` を追加、`as` 削除

5. **npm audit fix**
   - 5 vulnerabilities (1 moderate / 4 high) 解消
   - next **16.1.6 → 16.2.3 (minor upgrade)** — semver 上 minor は breaking 含み得るが、`^16.1.6` 範囲内・`package.json` 変更なし・`package-lock.json` のみ更新・ローカル + CI 両方でテスト 1415/1420 pass を確認
   - picomatch / vite 子依存も refresh

## テスト結果

- 1414 passed → **1415 passed**
- 失敗5件（feedback-engine/auto-feedback timeouts）は本PRスコープ外の独立した timeout 問題。`adf-dev-state.md` で追跡中
- `npm audit` → **0 vulnerabilities**
- `npx tsc --noEmit -p tsconfig.cli.json` → **0 errors**
- `npx tsc --noEmit` (Next.js root) → **0 errors**

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.cli.json` エラー0
- [x] `npx tsc --noEmit` (Next.js root) エラー0
- [x] `npm test` worktree-manager.test.ts 16/16 pass
- [x] `npm audit` 脆弱性0
- [x] **CIグリーン確認** — 全8/8 pass: https://github.com/watchout/ai-dev-framework/actions/runs/24323381966
  - Build / CLI Smoke Tests / Critical Gate / Hardcoded Secrets Scan / Lint / Security Audit / Type Check / Unit Tests

## Route label

`route:fast-merge`（bug fix / 依存minor upgrade、公開API・DB・pricing変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)