### PR TITLE
feat(gate-a): profile catalog expansion (mcp-server/library) + profile-aware Gate A

### DIFF
--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -28,7 +28,15 @@ import {
   type SSOTGateEntry,
 } from "../lib/gate-model.js";
 import { scaffoldGateCsections } from "../lib/gate-scaffold.js";
-import { loadProjectProfile } from "../lib/profile-model.js";
+import {
+  loadProjectProfile,
+  PROFILE_TYPES,
+  isValidProfileType,
+  type ProfileType,
+} from "../lib/profile-model.js";
+
+const PROFILE_HELP = `Project profile (${PROFILE_TYPES.join("|")}). Overrides .framework/project.json. Affects Gate A requirements.`;
+const PROFILE_VALID_LIST = PROFILE_TYPES.join(", ");
 import { logger } from "../lib/logger.js";
 import {
   runGateDVerify,
@@ -49,32 +57,18 @@ export function registerGateCommand(program: Command): void {
   gate
     .command("check")
     .description("Run all gate checks (A, B, C)")
-    .option(
-      "--profile <type>",
-      "Project profile (app|api|mcp-server|cli|library|lp|hp). Overrides .framework/project.json. Affects Gate A requirements.",
-    )
+    .option("--profile <type>", PROFILE_HELP)
     .action(async (options: { profile?: string }) => {
       const projectDir = process.cwd();
 
       try {
-        const { isValidProfileType } = await import(
-          "../lib/profile-model.js"
-        );
         if (options.profile && !isValidProfileType(options.profile)) {
           logger.error(
-            `Invalid --profile value: "${options.profile}". Valid: app, api, mcp-server, cli, library, lp, hp.`,
+            `Invalid --profile value: "${options.profile}". Valid: ${PROFILE_VALID_LIST}.`,
           );
           process.exit(1);
         }
-        const profile = options.profile as
-          | "app"
-          | "api"
-          | "mcp-server"
-          | "cli"
-          | "library"
-          | "lp"
-          | "hp"
-          | undefined;
+        const profile = options.profile as ProfileType | undefined;
 
         const io = createGateTerminalIO();
 
@@ -119,32 +113,15 @@ export function registerGateCommand(program: Command): void {
   gate
     .command("check-a")
     .description("Run Gate A only (environment readiness)")
-    .option(
-      "--profile <type>",
-      "Project profile (app|api|mcp-server|cli|library|lp|hp). Overrides .framework/project.json.",
-    )
+    .option("--profile <type>", PROFILE_HELP)
     .action(async (options: { profile?: string }) => {
-      const { isValidProfileType } = await import(
-        "../lib/profile-model.js"
-      );
       if (options.profile && !isValidProfileType(options.profile)) {
         logger.error(
-          `Invalid --profile value: "${options.profile}". Valid: app, api, mcp-server, cli, library, lp, hp.`,
+          `Invalid --profile value: "${options.profile}". Valid: ${PROFILE_VALID_LIST}.`,
         );
         process.exit(1);
       }
-      runSingleGateCheck(
-        "A",
-        options.profile as
-          | "app"
-          | "api"
-          | "mcp-server"
-          | "cli"
-          | "library"
-          | "lp"
-          | "hp"
-          | undefined,
-      );
+      runSingleGateCheck("A", options.profile as ProfileType | undefined);
     });
 
   // framework gate check-b
@@ -833,7 +810,7 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
 
 function runSingleGateCheck(
   gateId: "A" | "B" | "C",
-  profile?: "app" | "api" | "mcp-server" | "cli" | "library" | "lp" | "hp",
+  profile?: ProfileType,
 ): void {
   const projectDir = process.cwd();
 

--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -49,10 +49,33 @@ export function registerGateCommand(program: Command): void {
   gate
     .command("check")
     .description("Run all gate checks (A, B, C)")
-    .action(async () => {
+    .option(
+      "--profile <type>",
+      "Project profile (app|api|mcp-server|cli|library|lp|hp). Overrides .framework/project.json. Affects Gate A requirements.",
+    )
+    .action(async (options: { profile?: string }) => {
       const projectDir = process.cwd();
 
       try {
+        const { isValidProfileType } = await import(
+          "../lib/profile-model.js"
+        );
+        if (options.profile && !isValidProfileType(options.profile)) {
+          logger.error(
+            `Invalid --profile value: "${options.profile}". Valid: app, api, mcp-server, cli, library, lp, hp.`,
+          );
+          process.exit(1);
+        }
+        const profile = options.profile as
+          | "app"
+          | "api"
+          | "mcp-server"
+          | "cli"
+          | "library"
+          | "lp"
+          | "hp"
+          | undefined;
+
         const io = createGateTerminalIO();
 
         io.print("");
@@ -60,7 +83,7 @@ export function registerGateCommand(program: Command): void {
         io.print("  PRE-CODE GATE CHECK");
         io.print("━".repeat(42));
 
-        const result = checkAllGates(projectDir, io);
+        const result = checkAllGates(projectDir, io, profile);
 
         io.print("");
         io.print("━".repeat(42));
@@ -96,8 +119,32 @@ export function registerGateCommand(program: Command): void {
   gate
     .command("check-a")
     .description("Run Gate A only (environment readiness)")
-    .action(async () => {
-      runSingleGateCheck("A");
+    .option(
+      "--profile <type>",
+      "Project profile (app|api|mcp-server|cli|library|lp|hp). Overrides .framework/project.json.",
+    )
+    .action(async (options: { profile?: string }) => {
+      const { isValidProfileType } = await import(
+        "../lib/profile-model.js"
+      );
+      if (options.profile && !isValidProfileType(options.profile)) {
+        logger.error(
+          `Invalid --profile value: "${options.profile}". Valid: app, api, mcp-server, cli, library, lp, hp.`,
+        );
+        process.exit(1);
+      }
+      runSingleGateCheck(
+        "A",
+        options.profile as
+          | "app"
+          | "api"
+          | "mcp-server"
+          | "cli"
+          | "library"
+          | "lp"
+          | "hp"
+          | undefined,
+      );
     });
 
   // framework gate check-b
@@ -784,7 +831,10 @@ ${testOutput.slice(0, 5000)}${testOutput.length > 5000 ? "\n... (truncated)" : "
 // Helpers
 // ─────────────────────────────────────────────
 
-function runSingleGateCheck(gateId: "A" | "B" | "C"): void {
+function runSingleGateCheck(
+  gateId: "A" | "B" | "C",
+  profile?: "app" | "api" | "mcp-server" | "cli" | "library" | "lp" | "hp",
+): void {
   const projectDir = process.cwd();
 
   try {
@@ -800,7 +850,7 @@ function runSingleGateCheck(gateId: "A" | "B" | "C"): void {
     io.print(`  GATE ${gateId}: ${gateLabels[gateId]}`);
     io.print("━".repeat(42));
 
-    const result = checkSingleGate(projectDir, gateId, io);
+    const result = checkSingleGate(projectDir, gateId, io, profile);
     io.print("");
 
     const gateEntry =

--- a/src/cli/lib/gate-engine.test.ts
+++ b/src/cli/lib/gate-engine.test.ts
@@ -719,6 +719,92 @@ describe("gate-engine", () => {
       expect(docker?.message).toMatch(/Skipped for profile 'cli'/);
     });
 
+    it("DB migration emits status=warning (data-layer, not just string prefix)", () => {
+      // Regression guard for codex-auditor PR #54 cycle 3 finding:
+      // WARNING must be represented as a structured enum on the check,
+      // not only as a message prefix. This lets JSON consumers /
+      // gate-state aggregators distinguish warnings from clean passes.
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "docker-compose.yml"), "", "utf-8");
+      // No migrations dir
+
+      const checks = checkGateA(tmpDir, "api");
+      const db = checks.find(
+        (c) => c.name === "Database migrations directory",
+      );
+      expect(db?.passed).toBe(true);
+      expect(db?.status).toBe("warning");
+    });
+
+    it("DB migration emits status=pass when migrations exist", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "docker-compose.yml"), "", "utf-8");
+      fs.mkdirSync(path.join(tmpDir, "prisma/migrations"), { recursive: true });
+
+      const checks = checkGateA(tmpDir, "api");
+      const db = checks.find(
+        (c) => c.name === "Database migrations directory",
+      );
+      expect(db?.status).toBe("pass");
+    });
+
+    it("persisted gates.json retains per-check status enum", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "docker-compose.yml"), "", "utf-8");
+      // No migrations → warning
+
+      checkSingleGate(tmpDir, "A", undefined, "api");
+      const loaded = loadGateState(tmpDir);
+      const db = loaded!.gateA.checks.find(
+        (c) => c.name === "Database migrations directory",
+      );
+      expect(db?.status).toBe("warning");
+      // Gate A itself is still "passed" — warnings are non-blocking
+      expect(loaded!.gateA.status).toBe("passed");
+    });
+
+    it("failing check emits status=fail", () => {
+      // No package.json → fail
+      const checks = checkGateA(tmpDir);
+      const pkg = checks.find((c) => c.name === "package.json exists");
+      expect(pkg?.passed).toBe(false);
+      expect(pkg?.status).toBe("fail");
+    });
+
+    it("profile-skipped checks emit status=skip (data-layer), not silent pass", () => {
+      // Regression guard for codex-auditor PR #54 cycle 4 finding:
+      // "Skipped for profile ..." entries were previously emitted as
+      // status=pass, leaving skip indistinguishable from a real pass
+      // in any state consumer that isn't the print formatter.
+      writeBasicProject(tmpDir);
+      const checks = checkGateA(tmpDir, "cli");
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      const db = checks.find(
+        (c) => c.name === "Database migrations directory",
+      );
+      const envCfg = checks.find(
+        (c) => c.name === "Environment config (.env or .env.example)",
+      );
+      expect(docker?.status).toBe("skip");
+      expect(db?.status).toBe("skip");
+      expect(envCfg?.status).toBe("skip");
+    });
+
+    it("skipped checks are visible in print output with reason", () => {
+      // Companion to cycle 4 finding: the CLI MUST surface skip reasons,
+      // otherwise the PR-body claim "skipped entry is emitted" is a lie.
+      writeBasicProject(tmpDir);
+      const output: string[] = [];
+      const io = { print: (line: string) => output.push(line) };
+      checkSingleGate(tmpDir, "A", io, "cli");
+      const joined = output.join("\n");
+      expect(joined).toMatch(/⏭️/);
+      expect(joined).toMatch(/Skipped for profile 'cli'/);
+    });
+
     it("WARNING checks are visible in print output (not silent pass)", async () => {
       // Regression guard for codex-auditor PR #54 cycle 2 finding:
       // printChecks was hiding passed:true messages, making the DB

--- a/src/cli/lib/gate-engine.test.ts
+++ b/src/cli/lib/gate-engine.test.ts
@@ -788,9 +788,9 @@ describe("gate-engine", () => {
       const envCfg = checks.find(
         (c) => c.name === "Environment config (.env or .env.example)",
       );
-      expect(docker?.status).toBe("skip");
-      expect(db?.status).toBe("skip");
-      expect(envCfg?.status).toBe("skip");
+      expect(docker?.status).toBe("skipped");
+      expect(db?.status).toBe("skipped");
+      expect(envCfg?.status).toBe("skipped");
     });
 
     it("skipped checks are visible in print output with reason", () => {

--- a/src/cli/lib/gate-engine.test.ts
+++ b/src/cli/lib/gate-engine.test.ts
@@ -23,12 +23,26 @@ describe("gate-engine", () => {
   });
 
   describe("checkGateA", () => {
-    it("fails when no files exist", () => {
+    it("fails when no files exist (except DB migration which is WARNING-only)", () => {
       const checks = checkGateA(tmpDir);
       expect(checks.length).toBeGreaterThan(0);
-      const passed = checks.filter((c) => c.passed);
-      // Nothing should pass in an empty directory
-      expect(passed.length).toBe(0);
+      // Hard-required checks must fail
+      const pkg = checks.find((c) => c.name === "package.json exists");
+      const nodeModules = checks.find(
+        (c) => c.name === "Dependencies installed (node_modules/)",
+      );
+      const envCfg = checks.find(
+        (c) => c.name === "Environment config (.env or .env.example)",
+      );
+      expect(pkg?.passed).toBe(false);
+      expect(nodeModules?.passed).toBe(false);
+      expect(envCfg?.passed).toBe(false);
+      // DB migration passes with WARNING per CEO 2026-04-13 directive
+      const db = checks.find(
+        (c) => c.name === "Database migrations directory",
+      );
+      expect(db?.passed).toBe(true);
+      expect(db?.message).toMatch(/WARNING/);
     });
 
     it("passes package.json check when file exists", () => {
@@ -638,7 +652,7 @@ describe("gate-engine", () => {
       expect(envExample?.passed).toBe(true);
     });
 
-    it("api profile: docker-compose + DB migration required (fails when absent)", () => {
+    it("api profile: docker-compose required (fails when absent), DB migration warns only (non-blocking)", () => {
       writeBasicProject(tmpDir);
       fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
 
@@ -648,7 +662,10 @@ describe("gate-engine", () => {
         c.name === "Database migrations directory",
       );
       expect(docker?.passed).toBe(false);
-      expect(db?.passed).toBe(false);
+      // CEO 2026-04-13 directive: DB migration missing is WARNING, not failure.
+      expect(db?.passed).toBe(true);
+      expect(db?.message).toMatch(/WARNING/);
+      expect(db?.message).toMatch(/non-blocking/);
     });
 
     it("api profile: passes when docker-compose + migrations exist", () => {

--- a/src/cli/lib/gate-engine.test.ts
+++ b/src/cli/lib/gate-engine.test.ts
@@ -574,4 +574,151 @@ describe("gate-engine", () => {
       expect(loaded!.gateA.status).toBe("pending");
     });
   });
+
+  describe("checkGateA profile support (CEO-approved matrix)", () => {
+    function writeBasicProject(dir: string) {
+      fs.writeFileSync(path.join(dir, "package.json"), "{}", "utf-8");
+      fs.mkdirSync(path.join(dir, "node_modules"), { recursive: true });
+      fs.mkdirSync(path.join(dir, ".framework"), { recursive: true });
+      fs.mkdirSync(path.join(dir, ".github/workflows"), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, ".github/workflows/ci.yml"),
+        "name: ci",
+        "utf-8",
+      );
+    }
+
+    it("mcp-server profile: skips docker-compose + DB migration, requires .env.example", () => {
+      writeBasicProject(tmpDir);
+      // no docker-compose, no migrations, but has .env.example
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+
+      const checks = checkGateA(tmpDir, "mcp-server");
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      const db = checks.find((c) =>
+        c.name === "Database migrations directory",
+      );
+      const envExample = checks.find((c) =>
+        c.name === "Environment config (.env or .env.example)",
+      );
+      expect(docker?.passed).toBe(true);
+      expect(docker?.message).toMatch(/Skipped for profile 'mcp-server'/);
+      expect(db?.passed).toBe(true);
+      expect(db?.message).toMatch(/Skipped for profile 'mcp-server'/);
+      expect(envExample?.passed).toBe(true);
+      expect(envExample?.message).toBe("Environment config found");
+    });
+
+    it("cli profile: skips docker-compose, DB migration, AND .env.example", () => {
+      writeBasicProject(tmpDir);
+      // No infra files at all.
+
+      const checks = checkGateA(tmpDir, "cli");
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      const db = checks.find((c) =>
+        c.name === "Database migrations directory",
+      );
+      const envExample = checks.find((c) =>
+        c.name === "Environment config (.env or .env.example)",
+      );
+      expect(docker?.passed).toBe(true);
+      expect(db?.passed).toBe(true);
+      expect(envExample?.passed).toBe(true);
+      expect(envExample?.message).toMatch(/Skipped for profile 'cli'/);
+    });
+
+    it("library profile: mirrors cli (same skip set)", () => {
+      writeBasicProject(tmpDir);
+      const checks = checkGateA(tmpDir, "library");
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      const envExample = checks.find((c) =>
+        c.name === "Environment config (.env or .env.example)",
+      );
+      expect(docker?.passed).toBe(true);
+      expect(envExample?.passed).toBe(true);
+    });
+
+    it("api profile: docker-compose + DB migration required (fails when absent)", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+
+      const checks = checkGateA(tmpDir, "api");
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      const db = checks.find((c) =>
+        c.name === "Database migrations directory",
+      );
+      expect(docker?.passed).toBe(false);
+      expect(db?.passed).toBe(false);
+    });
+
+    it("api profile: passes when docker-compose + migrations exist", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(
+        path.join(tmpDir, "docker-compose.yml"),
+        "version: '3'\n",
+        "utf-8",
+      );
+      fs.mkdirSync(path.join(tmpDir, "prisma/migrations"), { recursive: true });
+
+      const checks = checkGateA(tmpDir, "api");
+      const failed = checks.filter((c) => !c.passed);
+      expect(failed).toHaveLength(0);
+    });
+
+    it("app profile (default): behaves like explicit 'app' when no profile given", () => {
+      writeBasicProject(tmpDir);
+      const checksDefault = checkGateA(tmpDir);
+      const checksApp = checkGateA(tmpDir, "app");
+      // Both should yield the same pass/fail pattern.
+      expect(checksDefault.map((c) => c.passed)).toEqual(
+        checksApp.map((c) => c.passed),
+      );
+    });
+
+    it("reads profile from .framework/project.json when not explicitly passed", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(
+        path.join(tmpDir, ".framework/project.json"),
+        JSON.stringify({ profileType: "mcp-server" }),
+        "utf-8",
+      );
+      const checks = checkGateA(tmpDir); // no explicit profile
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      expect(docker?.passed).toBe(true);
+      expect(docker?.message).toMatch(/Skipped for profile 'mcp-server'/);
+    });
+
+    it("explicit --profile argument overrides project.json", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(
+        path.join(tmpDir, ".framework/project.json"),
+        JSON.stringify({ profileType: "app" }), // would require docker-compose
+        "utf-8",
+      );
+      const checks = checkGateA(tmpDir, "cli"); // explicit override
+      const docker = checks.find((c) => c.name === "Docker Compose config");
+      expect(docker?.passed).toBe(true);
+      expect(docker?.message).toMatch(/Skipped for profile 'cli'/);
+    });
+
+    it("accepts various migrations directory layouts", () => {
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(
+        path.join(tmpDir, "docker-compose.yml"),
+        "",
+        "utf-8",
+      );
+      // supabase/migrations instead of prisma/migrations
+      fs.mkdirSync(path.join(tmpDir, "supabase/migrations"), {
+        recursive: true,
+      });
+      const checks = checkGateA(tmpDir, "api");
+      const db = checks.find((c) =>
+        c.name === "Database migrations directory",
+      );
+      expect(db?.passed).toBe(true);
+    });
+  });
 });

--- a/src/cli/lib/gate-engine.test.ts
+++ b/src/cli/lib/gate-engine.test.ts
@@ -719,6 +719,26 @@ describe("gate-engine", () => {
       expect(docker?.message).toMatch(/Skipped for profile 'cli'/);
     });
 
+    it("WARNING checks are visible in print output (not silent pass)", async () => {
+      // Regression guard for codex-auditor PR #54 cycle 2 finding:
+      // printChecks was hiding passed:true messages, making the DB
+      // migration WARNING effectively silent in `framework gate check`.
+      writeBasicProject(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "docker-compose.yml"), "", "utf-8");
+      // No migrations dir → DB migration check should emit WARNING
+
+      const output: string[] = [];
+      const io = { print: (line: string) => output.push(line) };
+      checkSingleGate(tmpDir, "A", io, "api");
+
+      const joined = output.join("\n");
+      expect(joined).toMatch(/⚠️/);
+      expect(joined).toMatch(/Database migrations directory/);
+      expect(joined).toMatch(/WARNING/);
+      expect(joined).toMatch(/non-blocking/);
+    });
+
     it("accepts various migrations directory layouts", () => {
       writeBasicProject(tmpDir);
       fs.writeFileSync(path.join(tmpDir, ".env.example"), "", "utf-8");

--- a/src/cli/lib/gate-engine.ts
+++ b/src/cli/lib/gate-engine.ts
@@ -739,7 +739,7 @@ function iconFor(status: GateCheck["status"]): string {
       return "  ❌";
     case "warning":
       return "  ⚠️ ";
-    case "skip":
+    case "skipped":
       return "  ⏭️ ";
     case "pass":
       return "  ✅";

--- a/src/cli/lib/gate-engine.ts
+++ b/src/cli/lib/gate-engine.ts
@@ -684,9 +684,11 @@ function isSectionEmpty(content: string, sectionId: string): boolean {
 function printChecks(io: GateIO | undefined, checks: GateCheck[]): void {
   if (!io) return;
   for (const check of checks) {
-    const icon = check.passed ? "  ✅" : "  ❌";
+    const isWarning =
+      check.passed && check.message.startsWith("WARNING");
+    const icon = !check.passed ? "  ❌" : isWarning ? "  ⚠️ " : "  ✅";
     io.print(`${icon} ${check.name}`);
-    if (!check.passed) {
+    if (!check.passed || isWarning) {
       io.print(`     → ${check.message}`);
     }
   }

--- a/src/cli/lib/gate-engine.ts
+++ b/src/cli/lib/gate-engine.ts
@@ -132,6 +132,15 @@ export function checkGateA(
   }
 
   // DB migration — conditional on profile. Accepts any of the common layouts.
+  //
+  // Policy (CEO 2026-04-13 directive): for profiles where DB is expected
+  // (app/api/lp/hp), a missing migrations directory emits a **WARNING only**
+  // (passed: true) rather than failing Gate A. Rationale: existing adopter
+  // repos (hotel-kanri, haishin-puls-hub, etc.) have not been verified to
+  // conform to the canonical layouts; failing them unannounced is the same
+  // class of breaking change as PR #164 (S2-A fallback removal). The check
+  // will be promoted to required in a follow-up PR after all adopters are
+  // audited and migrated.
   if (reqs.dbMigration) {
     const hasMigrations =
       fs.existsSync(path.join(projectDir, "prisma/migrations")) ||
@@ -141,10 +150,10 @@ export function checkGateA(
       fs.existsSync(path.join(projectDir, "drizzle"));
     checks.push({
       name: "Database migrations directory",
-      passed: hasMigrations,
+      passed: true,
       message: hasMigrations
         ? "Migrations directory found"
-        : "No migrations directory found (prisma/migrations, migrations/, db/migrations/, supabase/migrations/, or drizzle/).",
+        : "WARNING: No migrations directory found (prisma/migrations, migrations/, db/migrations/, supabase/migrations/, or drizzle/). Consider adding one. (non-blocking pending framework-wide audit)",
     });
   } else {
     checks.push({

--- a/src/cli/lib/gate-engine.ts
+++ b/src/cli/lib/gate-engine.ts
@@ -24,6 +24,10 @@ import {
   buildAllGatesResult,
   loadGateState,
   saveGateState,
+  passCheck,
+  failCheck,
+  warnCheck,
+  skipCheck,
 } from "./gate-model.js";
 import { loadPlan } from "./plan-model.js";
 import {
@@ -94,19 +98,25 @@ export function checkGateA(
   if (reqs.envExample) {
     const hasEnv = fs.existsSync(path.join(projectDir, ".env"));
     const hasEnvExample = fs.existsSync(path.join(projectDir, ".env.example"));
-    checks.push({
-      name: "Environment config (.env or .env.example)",
-      passed: hasEnv || hasEnvExample,
-      message: hasEnv || hasEnvExample
-        ? "Environment config found"
-        : ".env or .env.example not found. Create environment config.",
-    });
+    const ok = hasEnv || hasEnvExample;
+    checks.push(
+      ok
+        ? passCheck(
+            "Environment config (.env or .env.example)",
+            "Environment config found",
+          )
+        : failCheck(
+            "Environment config (.env or .env.example)",
+            ".env or .env.example not found. Create environment config.",
+          ),
+    );
   } else {
-    checks.push({
-      name: "Environment config (.env or .env.example)",
-      passed: true,
-      message: `Skipped for profile '${effectiveProfile}' (no environment variables expected)`,
-    });
+    checks.push(
+      skipCheck(
+        "Environment config (.env or .env.example)",
+        `Skipped for profile '${effectiveProfile}' (no environment variables expected)`,
+      ),
+    );
   }
 
   // docker-compose — conditional on profile
@@ -116,19 +126,21 @@ export function checkGateA(
       fs.existsSync(path.join(projectDir, "docker-compose.yaml")) ||
       fs.existsSync(path.join(projectDir, "compose.yml")) ||
       fs.existsSync(path.join(projectDir, "compose.yaml"));
-    checks.push({
-      name: "Docker Compose config",
-      passed: hasDockerCompose,
-      message: hasDockerCompose
-        ? "Docker Compose config found"
-        : "docker-compose.yml not found. DB/Redis may not be available.",
-    });
+    checks.push(
+      hasDockerCompose
+        ? passCheck("Docker Compose config", "Docker Compose config found")
+        : failCheck(
+            "Docker Compose config",
+            "docker-compose.yml not found. DB/Redis may not be available.",
+          ),
+    );
   } else {
-    checks.push({
-      name: "Docker Compose config",
-      passed: true,
-      message: `Skipped for profile '${effectiveProfile}' (no local infra services required)`,
-    });
+    checks.push(
+      skipCheck(
+        "Docker Compose config",
+        `Skipped for profile '${effectiveProfile}' (no local infra services required)`,
+      ),
+    );
   }
 
   // DB migration — conditional on profile. Accepts any of the common layouts.
@@ -148,19 +160,24 @@ export function checkGateA(
       fs.existsSync(path.join(projectDir, "db/migrations")) ||
       fs.existsSync(path.join(projectDir, "supabase/migrations")) ||
       fs.existsSync(path.join(projectDir, "drizzle"));
-    checks.push({
-      name: "Database migrations directory",
-      passed: true,
-      message: hasMigrations
-        ? "Migrations directory found"
-        : "WARNING: No migrations directory found (prisma/migrations, migrations/, db/migrations/, supabase/migrations/, or drizzle/). Consider adding one. (non-blocking pending framework-wide audit)",
-    });
+    checks.push(
+      hasMigrations
+        ? passCheck(
+            "Database migrations directory",
+            "Migrations directory found",
+          )
+        : warnCheck(
+            "Database migrations directory",
+            "WARNING: No migrations directory found (prisma/migrations, migrations/, db/migrations/, supabase/migrations/, or drizzle/). Consider adding one. (non-blocking pending framework-wide audit)",
+          ),
+    );
   } else {
-    checks.push({
-      name: "Database migrations directory",
-      passed: true,
-      message: `Skipped for profile '${effectiveProfile}' (no database expected)`,
-    });
+    checks.push(
+      skipCheck(
+        "Database migrations directory",
+        `Skipped for profile '${effectiveProfile}' (no database expected)`,
+      ),
+    );
   }
 
   // CI config — required for ALL profiles per CEO-approved matrix
@@ -169,20 +186,25 @@ export function checkGateA(
       fs.existsSync(path.join(projectDir, ".github/workflows")) ||
       fs.existsSync(path.join(projectDir, ".github/workflows/ci.yml")) ||
       fs.existsSync(path.join(projectDir, ".github/workflows/ci.yaml"));
-    checks.push({
-      name: "CI configuration (.github/workflows/)",
-      passed: hasCIConfig,
-      message: hasCIConfig
-        ? "CI configuration found"
-        : ".github/workflows/ not found. Run 'framework ci' to set up CI.",
-    });
+    checks.push(
+      hasCIConfig
+        ? passCheck(
+            "CI configuration (.github/workflows/)",
+            "CI configuration found",
+          )
+        : failCheck(
+            "CI configuration (.github/workflows/)",
+            ".github/workflows/ not found. Run 'framework ci' to set up CI.",
+          ),
+    );
   } else {
     // Reserved for future profiles; no current profile skips CI.
-    checks.push({
-      name: "CI configuration (.github/workflows/)",
-      passed: true,
-      message: `Skipped for profile '${effectiveProfile}'`,
-    });
+    checks.push(
+      skipCheck(
+        "CI configuration (.github/workflows/)",
+        `Skipped for profile '${effectiveProfile}'`,
+      ),
+    );
   }
 
   // .framework/ directory — required for ALL profiles
@@ -208,13 +230,17 @@ export function checkGateB(projectDir: string): GateCheck[] {
 
   // Check .framework/plan.json exists
   const plan = loadPlan(projectDir);
-  checks.push({
-    name: "Implementation plan (.framework/plan.json)",
-    passed: plan !== null,
-    message: plan !== null
-      ? `Plan found: ${plan.waves.length} waves, status=${plan.status}`
-      : "No plan found. Run 'framework plan' to generate.",
-  });
+  checks.push(
+    plan !== null
+      ? passCheck(
+          "Implementation plan (.framework/plan.json)",
+          `Plan found: ${plan.waves.length} waves, status=${plan.status}`,
+        )
+      : failCheck(
+          "Implementation plan (.framework/plan.json)",
+          "No plan found. Run 'framework plan' to generate.",
+        ),
+  );
 
   // Check plan has waves/features
   if (plan) {
@@ -222,34 +248,43 @@ export function checkGateB(projectDir: string): GateCheck[] {
       (sum, w) => sum + w.features.length,
       0,
     );
-    checks.push({
-      name: "Plan contains features",
-      passed: totalFeatures > 0,
-      message: totalFeatures > 0
-        ? `${totalFeatures} features across ${plan.waves.length} waves`
-        : "Plan has no features. Re-run 'framework plan'.",
-    });
+    checks.push(
+      totalFeatures > 0
+        ? passCheck(
+            "Plan contains features",
+            `${totalFeatures} features across ${plan.waves.length} waves`,
+          )
+        : failCheck(
+            "Plan contains features",
+            "Plan has no features. Re-run 'framework plan'.",
+          ),
+    );
   } else {
-    checks.push({
-      name: "Plan contains features",
-      passed: false,
-      message: "Cannot check features — no plan exists.",
-    });
+    checks.push(
+      failCheck(
+        "Plan contains features",
+        "Cannot check features — no plan exists.",
+      ),
+    );
   }
 
   // Check .framework/project.json exists (profile configured)
   const hasProject = fs.existsSync(
     path.join(projectDir, ".framework/project.json"),
   );
-  checks.push({
-    name: "Project profile configured (.framework/project.json)",
-    passed: hasProject,
-    message: hasProject
-      ? "Project profile found"
-      : "No project profile. Run 'framework retrofit' again to generate .framework/project.json.",
-  });
+  checks.push(
+    hasProject
+      ? passCheck(
+          "Project profile configured (.framework/project.json)",
+          "Project profile found",
+        )
+      : failCheck(
+          "Project profile configured (.framework/project.json)",
+          "No project profile. Run 'framework retrofit' again to generate .framework/project.json.",
+        ),
+  );
 
-  // Check GitHub Issues sync (informational — does not fail Gate B)
+  // Check GitHub Issues sync (advisory — does not fail Gate B)
   const syncState = loadSyncState(projectDir);
   if (syncState && plan) {
     const totalFeatures = plan.waves.reduce(
@@ -257,13 +292,17 @@ export function checkGateB(projectDir: string): GateCheck[] {
       0,
     );
     const syncedFeatures = syncState.featureIssues.length;
-    checks.push({
-      name: "GitHub Issues synced (informational)",
-      passed: true, // Always passes — informational only
-      message: syncedFeatures >= totalFeatures
-        ? `All ${syncedFeatures} features synced to GitHub Issues`
-        : `${syncedFeatures}/${totalFeatures} features synced. Run 'framework plan --sync' to sync remaining.`,
-    });
+    checks.push(
+      syncedFeatures >= totalFeatures
+        ? passCheck(
+            "GitHub Issues synced (informational)",
+            `All ${syncedFeatures} features synced to GitHub Issues`,
+          )
+        : warnCheck(
+            "GitHub Issues synced (informational)",
+            `${syncedFeatures}/${totalFeatures} features synced. Run 'framework plan --sync' to sync remaining.`,
+          ),
+    );
   }
 
   return checks;
@@ -313,6 +352,7 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
     checks.push({
       name: "Gate C (profile: " + profileType + ")",
       passed: true,
+      status: "pass",
       message: `Profile '${profileType}' does not require feature spec completeness. Gate C auto-passed.`,
       filePath: "",
       missingSections: [],
@@ -327,6 +367,7 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
     checks.push({
       name: "Gate C (new-format SSOT-0~5)",
       passed: true,
+      status: "pass",
       message: `New-format SSOT detected (${newFormatFiles.length} files: ${fileList.join(", ")}). Gate C auto-passed.`,
       filePath: "",
       missingSections: [],
@@ -343,6 +384,7 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
     checks.push({
       name: "SSOT files found",
       passed: false,
+      status: "fail",
       message: "No SSOT feature spec files found in docs/. Create feature specifications first.",
       filePath: "",
       missingSections: [],
@@ -374,6 +416,7 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
     checks.push({
       name: `${relativePath}`,
       passed,
+      status: passed ? "pass" : "fail",
       message: passed
         ? `${relativePath}: All required sections present`
         : `${relativePath}: Missing ${missingSections.join(", ")}`,
@@ -473,11 +516,9 @@ function checkFileExists(
   failMessage: string,
 ): GateCheck {
   const exists = fs.existsSync(path.join(projectDir, relativePath));
-  return {
-    name,
-    passed: exists,
-    message: exists ? `${name}: found` : failMessage,
-  };
+  return exists
+    ? passCheck(name, `${name}: found`)
+    : failCheck(name, failMessage);
 }
 
 function checkDirExists(
@@ -488,11 +529,9 @@ function checkDirExists(
 ): GateCheck {
   const dirPath = path.join(projectDir, relativePath);
   const exists = fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory();
-  return {
-    name,
-    passed: exists,
-    message: exists ? `${name}: found` : failMessage,
-  };
+  return exists
+    ? passCheck(name, `${name}: found`)
+    : failCheck(name, failMessage);
 }
 
 /** Pattern matching new-format SSOT file names (SSOT-0 through SSOT-5) */
@@ -684,12 +723,25 @@ function isSectionEmpty(content: string, sectionId: string): boolean {
 function printChecks(io: GateIO | undefined, checks: GateCheck[]): void {
   if (!io) return;
   for (const check of checks) {
-    const isWarning =
-      check.passed && check.message.startsWith("WARNING");
-    const icon = !check.passed ? "  ❌" : isWarning ? "  ⚠️ " : "  ✅";
+    const icon = iconFor(check.status);
     io.print(`${icon} ${check.name}`);
-    if (!check.passed || isWarning) {
+    // Surface reason for anything that isn't a clean pass, so warnings
+    // and skip reasons are visible (not silent).
+    if (check.status !== "pass") {
       io.print(`     → ${check.message}`);
     }
+  }
+}
+
+function iconFor(status: GateCheck["status"]): string {
+  switch (status) {
+    case "fail":
+      return "  ❌";
+    case "warning":
+      return "  ⚠️ ";
+    case "skip":
+      return "  ⏭️ ";
+    case "pass":
+      return "  ✅";
   }
 }

--- a/src/cli/lib/gate-engine.ts
+++ b/src/cli/lib/gate-engine.ts
@@ -26,7 +26,11 @@ import {
   saveGateState,
 } from "./gate-model.js";
 import { loadPlan } from "./plan-model.js";
-import type { ProfileType } from "./profile-model.js";
+import {
+  GATE_A_REQUIREMENTS,
+  loadProfileType,
+  type ProfileType,
+} from "./profile-model.js";
 
 // ─────────────────────────────────────────────
 // Public API
@@ -50,12 +54,27 @@ export function createGateTerminalIO(): GateIO {
 
 /**
  * Check development environment readiness.
- * Verifies file existence for environment prerequisites.
+ *
+ * Profile-aware: the GATE_A_REQUIREMENTS table (profile-model.ts)
+ * declares which infrastructure checks apply to a given profile.
+ * Skipped checks emit an informational "skipped" entry that passes
+ * without requiring the file/directory to exist.
+ *
+ * Profile resolution order:
+ *   1. Explicit `profile` argument (e.g., CLI --profile flag)
+ *   2. `.framework/project.json` profileType
+ *   3. Default: "app" (backward-compat with pre-profile behavior)
  */
-export function checkGateA(projectDir: string): GateCheck[] {
+export function checkGateA(
+  projectDir: string,
+  profile?: ProfileType,
+): GateCheck[] {
+  const effectiveProfile: ProfileType =
+    profile ?? loadProfileType(projectDir) ?? "app";
+  const reqs = GATE_A_REQUIREMENTS[effectiveProfile];
   const checks: GateCheck[] = [];
 
-  // Check package.json
+  // package.json — required for ALL profiles (Node.js project assumption)
   checks.push(checkFileExists(
     projectDir,
     "package.json",
@@ -63,7 +82,7 @@ export function checkGateA(projectDir: string): GateCheck[] {
     "package.json not found. Run 'npm init' or create package.json.",
   ));
 
-  // Check node_modules
+  // node_modules — required for ALL profiles
   checks.push(checkDirExists(
     projectDir,
     "node_modules",
@@ -71,45 +90,93 @@ export function checkGateA(projectDir: string): GateCheck[] {
     "node_modules/ not found. Run 'npm install' or 'pnpm install'.",
   ));
 
-  // Check .env or .env.example
-  const hasEnv = fs.existsSync(path.join(projectDir, ".env"));
-  const hasEnvExample = fs.existsSync(path.join(projectDir, ".env.example"));
-  checks.push({
-    name: "Environment config (.env or .env.example)",
-    passed: hasEnv || hasEnvExample,
-    message: hasEnv || hasEnvExample
-      ? "Environment config found"
-      : ".env or .env.example not found. Create environment config.",
-  });
+  // .env / .env.example — conditional on profile
+  if (reqs.envExample) {
+    const hasEnv = fs.existsSync(path.join(projectDir, ".env"));
+    const hasEnvExample = fs.existsSync(path.join(projectDir, ".env.example"));
+    checks.push({
+      name: "Environment config (.env or .env.example)",
+      passed: hasEnv || hasEnvExample,
+      message: hasEnv || hasEnvExample
+        ? "Environment config found"
+        : ".env or .env.example not found. Create environment config.",
+    });
+  } else {
+    checks.push({
+      name: "Environment config (.env or .env.example)",
+      passed: true,
+      message: `Skipped for profile '${effectiveProfile}' (no environment variables expected)`,
+    });
+  }
 
-  // Check docker-compose.yml (optional but flagged)
-  const hasDockerCompose =
-    fs.existsSync(path.join(projectDir, "docker-compose.yml")) ||
-    fs.existsSync(path.join(projectDir, "docker-compose.yaml")) ||
-    fs.existsSync(path.join(projectDir, "compose.yml")) ||
-    fs.existsSync(path.join(projectDir, "compose.yaml"));
-  checks.push({
-    name: "Docker Compose config",
-    passed: hasDockerCompose,
-    message: hasDockerCompose
-      ? "Docker Compose config found"
-      : "docker-compose.yml not found. DB/Redis may not be available.",
-  });
+  // docker-compose — conditional on profile
+  if (reqs.dockerCompose) {
+    const hasDockerCompose =
+      fs.existsSync(path.join(projectDir, "docker-compose.yml")) ||
+      fs.existsSync(path.join(projectDir, "docker-compose.yaml")) ||
+      fs.existsSync(path.join(projectDir, "compose.yml")) ||
+      fs.existsSync(path.join(projectDir, "compose.yaml"));
+    checks.push({
+      name: "Docker Compose config",
+      passed: hasDockerCompose,
+      message: hasDockerCompose
+        ? "Docker Compose config found"
+        : "docker-compose.yml not found. DB/Redis may not be available.",
+    });
+  } else {
+    checks.push({
+      name: "Docker Compose config",
+      passed: true,
+      message: `Skipped for profile '${effectiveProfile}' (no local infra services required)`,
+    });
+  }
 
-  // Check CI config
-  const hasCIConfig =
-    fs.existsSync(path.join(projectDir, ".github/workflows")) ||
-    fs.existsSync(path.join(projectDir, ".github/workflows/ci.yml")) ||
-    fs.existsSync(path.join(projectDir, ".github/workflows/ci.yaml"));
-  checks.push({
-    name: "CI configuration (.github/workflows/)",
-    passed: hasCIConfig,
-    message: hasCIConfig
-      ? "CI configuration found"
-      : ".github/workflows/ not found. Run 'framework ci' to set up CI.",
-  });
+  // DB migration — conditional on profile. Accepts any of the common layouts.
+  if (reqs.dbMigration) {
+    const hasMigrations =
+      fs.existsSync(path.join(projectDir, "prisma/migrations")) ||
+      fs.existsSync(path.join(projectDir, "migrations")) ||
+      fs.existsSync(path.join(projectDir, "db/migrations")) ||
+      fs.existsSync(path.join(projectDir, "supabase/migrations")) ||
+      fs.existsSync(path.join(projectDir, "drizzle"));
+    checks.push({
+      name: "Database migrations directory",
+      passed: hasMigrations,
+      message: hasMigrations
+        ? "Migrations directory found"
+        : "No migrations directory found (prisma/migrations, migrations/, db/migrations/, supabase/migrations/, or drizzle/).",
+    });
+  } else {
+    checks.push({
+      name: "Database migrations directory",
+      passed: true,
+      message: `Skipped for profile '${effectiveProfile}' (no database expected)`,
+    });
+  }
 
-  // Check .framework/ directory
+  // CI config — required for ALL profiles per CEO-approved matrix
+  if (reqs.ciConfig) {
+    const hasCIConfig =
+      fs.existsSync(path.join(projectDir, ".github/workflows")) ||
+      fs.existsSync(path.join(projectDir, ".github/workflows/ci.yml")) ||
+      fs.existsSync(path.join(projectDir, ".github/workflows/ci.yaml"));
+    checks.push({
+      name: "CI configuration (.github/workflows/)",
+      passed: hasCIConfig,
+      message: hasCIConfig
+        ? "CI configuration found"
+        : ".github/workflows/ not found. Run 'framework ci' to set up CI.",
+    });
+  } else {
+    // Reserved for future profiles; no current profile skips CI.
+    checks.push({
+      name: "CI configuration (.github/workflows/)",
+      passed: true,
+      message: `Skipped for profile '${effectiveProfile}'`,
+    });
+  }
+
+  // .framework/ directory — required for ALL profiles
   checks.push(checkDirExists(
     projectDir,
     ".framework",
@@ -219,21 +286,6 @@ function getRequiredSections(profileType?: ProfileType) {
 }
 
 /**
- * Load the project's profile type from .framework/project.json
- */
-function loadProfileType(projectDir: string): ProfileType | undefined {
-  const projectJsonPath = path.join(projectDir, ".framework/project.json");
-  if (!fs.existsSync(projectJsonPath)) return undefined;
-  try {
-    const raw = fs.readFileSync(projectJsonPath, "utf-8");
-    const data = JSON.parse(raw);
-    return data.profileType as ProfileType | undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
  * Check SSOT files for §3-E/F/G/H completeness.
  *
  * v4.0 improvements:
@@ -273,7 +325,7 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
     return checks;
   }
 
-  const requiredSections = getRequiredSections(profileType);
+  const requiredSections = getRequiredSections(profileType ?? undefined);
 
   // Find SSOT files in known locations
   const ssotPaths = findSSOTFiles(projectDir);
@@ -334,12 +386,13 @@ export function checkGateC(projectDir: string): SSOTCheck[] {
 export function checkAllGates(
   projectDir: string,
   io?: GateIO,
+  profile?: ProfileType,
 ): AllGatesResult {
   let state = loadGateState(projectDir) ?? createGateState();
 
   // Gate A
   io?.print("\n  [1/3] Gate A: Environment check...");
-  const checksA = checkGateA(projectDir);
+  const checksA = checkGateA(projectDir, profile);
   updateGateA(state, checksA);
   printChecks(io, checksA);
 
@@ -368,13 +421,14 @@ export function checkSingleGate(
   projectDir: string,
   gateId: "A" | "B" | "C",
   io?: GateIO,
+  profile?: ProfileType,
 ): AllGatesResult {
   let state = loadGateState(projectDir) ?? createGateState();
 
   switch (gateId) {
     case "A": {
       io?.print("\n  Gate A: Environment check...");
-      const checks = checkGateA(projectDir);
+      const checks = checkGateA(projectDir, profile);
       updateGateA(state, checks);
       printChecks(io, checks);
       break;

--- a/src/cli/lib/gate-model.test.ts
+++ b/src/cli/lib/gate-model.test.ts
@@ -249,6 +249,36 @@ describe("gate-model", () => {
       expect(loaded!.gateC.status).toBe("pending");
     });
 
+    it("migrates legacy gates.json without per-check status", () => {
+      // Regression guard for codex-auditor PR #54 cycle 5:
+      // Pre-CheckStatus gates.json stored only `passed`. loadGateState must
+      // synthesize `status` so downstream consumers can safely switch on it.
+      const frameworkDir = path.join(tmpDir, ".framework");
+      fs.mkdirSync(frameworkDir, { recursive: true });
+      const legacy = {
+        gateA: {
+          status: "failed",
+          checkedAt: "2024-01-01",
+          checks: [
+            { name: "pkg", passed: true, message: "found" },
+            { name: "env", passed: false, message: "missing" },
+          ],
+        },
+        gateB: { status: "pending", checks: [], checkedAt: "2024-01-01" },
+        gateC: { status: "pending", checks: [], checkedAt: "2024-01-01" },
+        updatedAt: "2024-01-01",
+      };
+      fs.writeFileSync(
+        path.join(frameworkDir, "gates.json"),
+        JSON.stringify(legacy),
+        "utf-8",
+      );
+
+      const loaded = loadGateState(tmpDir)!;
+      expect(loaded.gateA.checks[0].status).toBe("pass");
+      expect(loaded.gateA.checks[1].status).toBe("fail");
+    });
+
     it("returns null when no state file", () => {
       expect(loadGateState(tmpDir)).toBeNull();
     });

--- a/src/cli/lib/gate-model.test.ts
+++ b/src/cli/lib/gate-model.test.ts
@@ -19,18 +19,22 @@ import {
 } from "./gate-model.js";
 
 function makeCheck(overrides?: Partial<GateCheck>): GateCheck {
+  const passed = overrides?.passed ?? true;
   return {
     name: "test-check",
-    passed: true,
+    passed,
+    status: passed ? "pass" : "fail",
     message: "Check passed",
     ...overrides,
   };
 }
 
 function makeSSOTCheck(overrides?: Partial<SSOTCheck>): SSOTCheck {
+  const passed = overrides?.passed ?? true;
   return {
     name: "test-ssot-check",
-    passed: true,
+    passed,
+    status: passed ? "pass" : "fail",
     message: "SSOT check passed",
     filePath: "docs/feature.md",
     missingSections: [],

--- a/src/cli/lib/gate-model.ts
+++ b/src/cli/lib/gate-model.ts
@@ -19,10 +19,56 @@ import * as path from "node:path";
 export type GateId = "A" | "B" | "C";
 export type GateStatus = "passed" | "failed" | "pending";
 
+/**
+ * Per-check status. Distinct from `GateStatus` (which aggregates a whole gate).
+ *
+ * Four kinds — this is the SSOT for check severity across engine, state, and display:
+ *
+ * - "pass":    check succeeded
+ * - "warning": advisory; does NOT fail the gate (e.g. missing DB migrations,
+ *              per CEO 2026-04-13 directive — non-blocking pending audit)
+ * - "skip":    check is not applicable to the active profile; not an evaluation
+ *              result. Emitted with a human-readable reason for observability.
+ * - "fail":    blocks the gate
+ *
+ * `passed` is retained as a boolean convenience mirror:
+ *   passed === (status !== "fail")
+ * Warning / skip carry `passed: true` so gate aggregation (areAllGatesPassed /
+ * updateGateA/B/C) stays non-blocking, while the status enum lets display,
+ * persistence, and downstream aggregators distinguish each kind without
+ * parsing message strings.
+ */
+export type CheckStatus = "pass" | "warning" | "skip" | "fail";
+
 export interface GateCheck {
   name: string;
   passed: boolean;
+  status: CheckStatus;
   message: string;
+}
+
+export function passCheck(name: string, message: string): GateCheck {
+  return { name, passed: true, status: "pass", message };
+}
+
+export function failCheck(name: string, message: string): GateCheck {
+  return { name, passed: false, status: "fail", message };
+}
+
+export function warnCheck(name: string, message: string): GateCheck {
+  return { name, passed: true, status: "warning", message };
+}
+
+export function skipCheck(name: string, reason: string): GateCheck {
+  return { name, passed: true, status: "skip", message: reason };
+}
+
+export function isWarning(check: GateCheck): boolean {
+  return check.status === "warning";
+}
+
+export function isSkipped(check: GateCheck): boolean {
+  return check.status === "skip";
 }
 
 export interface SSOTCheck extends GateCheck {

--- a/src/cli/lib/gate-model.ts
+++ b/src/cli/lib/gate-model.ts
@@ -27,18 +27,18 @@ export type GateStatus = "passed" | "failed" | "pending";
  * - "pass":    check succeeded
  * - "warning": advisory; does NOT fail the gate (e.g. missing DB migrations,
  *              per CEO 2026-04-13 directive — non-blocking pending audit)
- * - "skip":    check is not applicable to the active profile; not an evaluation
+ * - "skipped": check is not applicable to the active profile; not an evaluation
  *              result. Emitted with a human-readable reason for observability.
  * - "fail":    blocks the gate
  *
  * `passed` is retained as a boolean convenience mirror:
  *   passed === (status !== "fail")
- * Warning / skip carry `passed: true` so gate aggregation (areAllGatesPassed /
+ * Warning / skipped carry `passed: true` so gate aggregation (areAllGatesPassed /
  * updateGateA/B/C) stays non-blocking, while the status enum lets display,
  * persistence, and downstream aggregators distinguish each kind without
  * parsing message strings.
  */
-export type CheckStatus = "pass" | "warning" | "skip" | "fail";
+export type CheckStatus = "pass" | "warning" | "skipped" | "fail";
 
 export interface GateCheck {
   name: string;
@@ -60,7 +60,7 @@ export function warnCheck(name: string, message: string): GateCheck {
 }
 
 export function skipCheck(name: string, reason: string): GateCheck {
-  return { name, passed: true, status: "skip", message: reason };
+  return { name, passed: true, status: "skipped", message: reason };
 }
 
 export function isWarning(check: GateCheck): boolean {
@@ -68,7 +68,7 @@ export function isWarning(check: GateCheck): boolean {
 }
 
 export function isSkipped(check: GateCheck): boolean {
-  return check.status === "skip";
+  return check.status === "skipped";
 }
 
 export interface SSOTCheck extends GateCheck {
@@ -233,9 +233,26 @@ export function loadGateState(
 
   try {
     const raw = fs.readFileSync(filePath, "utf-8");
-    return JSON.parse(raw) as GateState;
+    const parsed = JSON.parse(raw) as GateState;
+    // Backward-compat: pre-CheckStatus gates.json stored only `passed`.
+    // Synthesize `status` for any legacy entry so downstream consumers
+    // (print, aggregators, dashboards) can switch on the enum safely.
+    // Old data never encoded warning/skipped, so pass↔fail mirror is sound.
+    migrateLegacyChecks(parsed.gateA?.checks);
+    migrateLegacyChecks(parsed.gateB?.checks);
+    migrateLegacyChecks(parsed.gateC?.checks);
+    return parsed;
   } catch {
     return null;
+  }
+}
+
+function migrateLegacyChecks(checks: GateCheck[] | undefined): void {
+  if (!checks) return;
+  for (const c of checks) {
+    if (c.status === undefined) {
+      c.status = c.passed ? "pass" : "fail";
+    }
   }
 }
 

--- a/src/cli/lib/profile-model.test.ts
+++ b/src/cli/lib/profile-model.test.ts
@@ -21,9 +21,17 @@ describe("profile-model", () => {
   // ─────────────────────────────────────────────
 
   describe("PROFILE_TYPES", () => {
-    it("contains exactly 5 types", () => {
-      expect(PROFILE_TYPES).toHaveLength(5);
-      expect(PROFILE_TYPES).toEqual(["app", "lp", "hp", "api", "cli"]);
+    it("contains exactly 7 types", () => {
+      expect(PROFILE_TYPES).toHaveLength(7);
+      expect(PROFILE_TYPES).toEqual([
+        "app",
+        "lp",
+        "hp",
+        "api",
+        "cli",
+        "mcp-server",
+        "library",
+      ]);
     });
   });
 

--- a/src/cli/lib/profile-model.ts
+++ b/src/cli/lib/profile-model.ts
@@ -2,12 +2,14 @@
  * Project type profiles - defines project-type-specific configurations
  * Based on: templates/profiles/*.json from ai-dev-framework
  *
- * 5 project types:
+ * 7 project types:
  * - app: Full-stack application
  * - lp: Landing page
  * - hp: Homepage / Corporate site
  * - api: API / Backend service
  * - cli: CLI tool
+ * - mcp-server: MCP (Model Context Protocol) server
+ * - library: Reusable library / SDK / package
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -16,9 +18,53 @@ import * as path from "node:path";
 // Types
 // ─────────────────────────────────────────────
 
-export type ProfileType = "app" | "lp" | "hp" | "api" | "cli";
+export type ProfileType =
+  | "app"
+  | "lp"
+  | "hp"
+  | "api"
+  | "cli"
+  | "mcp-server"
+  | "library";
 
-export const PROFILE_TYPES: ProfileType[] = ["app", "lp", "hp", "api", "cli"];
+export const PROFILE_TYPES: ProfileType[] = [
+  "app",
+  "lp",
+  "hp",
+  "api",
+  "cli",
+  "mcp-server",
+  "library",
+];
+
+/**
+ * Gate A per-profile requirements matrix (CEO approved 2026-04-13).
+ *
+ * For each profile, declares whether a given Gate A infrastructure
+ * check is required. `false` means the check is skipped (emits an
+ * informational "skipped" entry rather than failing).
+ *
+ * lp/hp retain app-equivalent behavior for backward compatibility —
+ * the CEO-approved table only covers the 5 primary profiles; lp/hp
+ * are preserved with the previous (app-like) requirements.
+ */
+export interface GateARequirements {
+  dockerCompose: boolean;
+  dbMigration: boolean;
+  ciConfig: boolean;
+  envExample: boolean;
+}
+
+export const GATE_A_REQUIREMENTS: Record<ProfileType, GateARequirements> = {
+  app: { dockerCompose: true, dbMigration: true, ciConfig: true, envExample: true },
+  api: { dockerCompose: true, dbMigration: true, ciConfig: true, envExample: true },
+  "mcp-server": { dockerCompose: false, dbMigration: false, ciConfig: true, envExample: true },
+  cli: { dockerCompose: false, dbMigration: false, ciConfig: true, envExample: false },
+  library: { dockerCompose: false, dbMigration: false, ciConfig: true, envExample: false },
+  // Backward-compat: preserve prior Gate A behavior for lp/hp (treat like app).
+  lp: { dockerCompose: true, dbMigration: true, ciConfig: true, envExample: true },
+  hp: { dockerCompose: true, dbMigration: true, ciConfig: true, envExample: true },
+};
 
 export interface TechStackConfig {
   frontend: string | null;
@@ -310,6 +356,94 @@ const PROFILES: Record<ProfileType, ProjectProfile> = {
       hosting: "npm registry",
       testing: "Vitest",
       cli_framework: "Commander.js or oclif",
+    },
+  },
+  "mcp-server": {
+    id: "mcp-server",
+    name: "MCP Server",
+    description: "Model Context Protocol server (stdio or HTTP transport)",
+    enabledSsot: ["SSOT-0_PRD", "SSOT-3_API_CONTRACT"],
+    enabledAudit: ["code", "test"],
+    discoveryStages: [1, 2, 3],
+    freezeRequired: [1, 2, 3],
+    marketing: "none",
+    requiredTemplates: [
+      "docs/requirements/SSOT-0_PRD.md",
+      "docs/design/core/SSOT-3_API_CONTRACT.md",
+      "docs/standards/TECH_STACK.md",
+      "docs/standards/CODING_STANDARDS.md",
+      "docs/standards/TESTING_STANDARDS.md",
+    ],
+    skipTemplates: [
+      "SSOT-1_FEATURE_CATALOG",
+      "SSOT-2_UI_STATE",
+      "SSOT-4_DATA_MODEL",
+      "docs/design/features/common/",
+      "docs/marketing/",
+      "docs/growth/",
+      "docs/operations/",
+      "public/",
+    ],
+    directories: [
+      "docs/requirements",
+      "docs/design/core",
+      "docs/standards",
+      "docs/notes",
+      "docs/ssot",
+      "src",
+      "tests",
+    ],
+    defaultTechStack: {
+      frontend: null,
+      backend: "Node.js (TypeScript) MCP SDK",
+      database: null,
+      auth: null,
+      hosting: "stdio / npm registry",
+      testing: "Vitest",
+    },
+  },
+  library: {
+    id: "library",
+    name: "Library / SDK",
+    description: "再利用可能ライブラリ・SDK・パッケージ",
+    enabledSsot: ["SSOT-0_PRD", "SSOT-3_API_CONTRACT"],
+    enabledAudit: ["code", "test"],
+    discoveryStages: [1, 2, 3],
+    freezeRequired: [1, 2, 3],
+    marketing: "none",
+    requiredTemplates: [
+      "docs/requirements/SSOT-0_PRD.md",
+      "docs/design/core/SSOT-3_API_CONTRACT.md",
+      "docs/standards/TECH_STACK.md",
+      "docs/standards/CODING_STANDARDS.md",
+      "docs/standards/TESTING_STANDARDS.md",
+    ],
+    skipTemplates: [
+      "SSOT-1_FEATURE_CATALOG",
+      "SSOT-2_UI_STATE",
+      "SSOT-4_DATA_MODEL",
+      "docs/design/features/common/",
+      "docs/marketing/",
+      "docs/growth/",
+      "docs/operations/",
+      "public/",
+    ],
+    directories: [
+      "docs/requirements",
+      "docs/design/core",
+      "docs/standards",
+      "docs/notes",
+      "docs/ssot",
+      "src",
+      "tests",
+    ],
+    defaultTechStack: {
+      frontend: null,
+      backend: "TypeScript",
+      database: null,
+      auth: null,
+      hosting: "npm registry",
+      testing: "Vitest",
     },
   },
 };


### PR DESCRIPTION
## Summary (route:ceo-approval)

Two related changes bundled by type-system constraint (PROFILES Record is exhaustive over ProfileType, so adding profile types requires adding PROFILES entries):

1. **Profile catalog expansion**: adds `mcp-server` and `library` profile types (total: 7). Each gets full `ProjectProfile` entry (enabledSsot / requiredTemplates / skipTemplates / directories / defaultTechStack).
2. **Gate A profile-awareness**: `checkGateA` now consults a `GATE_A_REQUIREMENTS` matrix per profile. Skipped infrastructure checks emit an informational "skipped" entry.

## Route — `route:ceo-approval`

This PR tightens gate policy (adds a new DB migration check) which the 2026-04-13 governance-flow.md update classifies as a strategic decision, not fast-merge territory. Escalated per auditor review.

## Gate A requirements matrix (CEO approved 2026-04-13)

| profile | docker-compose | DB migration | .env | CI |
|---|---|---|---|---|
| app / api | required | WARNING | required | required |
| mcp-server | skipped | skipped | required | required |
| cli / library | skipped | skipped | skipped | required |
| lp / hp | required | WARNING | required | required (backward-compat) |

**DB migration is WARNING-only** (non-blocking) per CEO 2026-04-13 directive responding to codex-auditor regression concern. Existing adopter repos (hotel-kanri, haishin-puls-hub) have not been audited for canonical `migrations/` layouts; failing them unannounced would mirror the PR #164 (S2-A fallback removal) incident pattern. Will be promoted to required in a follow-up PR after framework-wide audit.

## Profile resolution order
1. `--profile` CLI flag (validated via `isValidProfileType`)
2. `.framework/project.json` `profileType` (already validated inside `loadProfileType`)
3. Default `"app"` (backward-compat)

Invalid values at any stage cannot reach `GATE_A_REQUIREMENTS[…]`: `loadProfileType` returns `null` on invalid input, and `Record<ProfileType, …>` is exhaustive. No runtime crash path exists.

## codex-auditor review response

| axis | verdict | resolution |
|---|---|---|
| intent | ✅ OK | — |
| scope bundle | 🟡 | Acknowledged — bundling is unavoidable due to exhaustive Record; this PR body now names both concerns |
| hidden impact | 🔴 BLOCK | **Rebutted** — `loadProfileType` already validates via `isValidProfileType` (profile-model.ts:586-615); invalid input → `null` → `"app"` fallback; no crash path |
| regression | 🟡 | **Resolved via commit `f2d8152`** — DB migration demoted to WARNING-only |
| SSOT | 🟡 | **Resolved via commit `65139f9`** — gate.ts hand-written union eliminated; all ProfileType/PROFILE_TYPES/isValidProfileType imported from profile-model |
| honesty | 🟡 | Acknowledged — route upgraded to `ceo-approval`, scope named in this PR body |

## Commits
- `237e799` — feat(gate-a): profile-aware Gate A + mcp-server/library profiles
- `65139f9` — refactor(gate): eliminate duplicated ProfileType union in gate CLI (SSOT fix)
- `f2d8152` — fix(gate-a): downgrade DB migration check to WARNING (regression fix)

## Test plan
- [x] `npm test -- --run src/cli/lib/gate-engine.test.ts src/cli/lib/profile-model.test.ts` → 90 passed (43 + 47)
- [x] existing app/api Gate A behavior preserved (no false failures for repos without `migrations/`)
- [x] `--profile` invalid value rejected with error listing valid types (dynamically derived from `PROFILE_TYPES`)
- [x] `.framework/project.json` with invalid `profileType` → `null` → `"app"` fallback (not crash)
- [ ] lead-bot review
- [ ] codex-auditor re-review (cycle 2)
- [ ] CTO tertiary review
- [ ] CEO explicit approval (route:ceo-approval)

## Pre-merge breaking-changes check (governance-flow.md 2026-04-13)

This PR introduces a new Gate A check (DB migrations). Applied mitigation: WARNING-only semantics means no existing adopter will see a Gate A failure from this PR. No fallback removal; no `?? default` deletion. Check passes the 2026-04-13 governance rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)