### PR TITLE
feat(tools): preflight check + breaking-change detection + Layer 0/1/2

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -1,0 +1,36 @@
+name: Breaking Change Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect breaking changes
+        id: detect
+        run: |
+          # Compare against the PR base ref (not always 'main' literal).
+          BASE="${{ github.event.pull_request.base.ref }}"
+          bash scripts/detect-breaking-changes.sh "origin/${BASE}"
+
+      - name: Require breaking-change-verified label
+        if: failure() && steps.detect.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes('breaking-change-verified')) {
+              core.setFailed(
+                "Breaking change patterns detected. " +
+                "Verify all affected consumers and add the " +
+                "'breaking-change-verified' label before merge."
+              );
+            } else {
+              core.info("Breaking change patterns detected but verification label present — allowing.");
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage/
 .framework/audits/
 .framework/feedback/
 .framework/remediation/
+.framework/preflight/
 
 # Worktrees (parallel execution)
 .worktrees/

--- a/docs/tools/audit-depth-control-v3.md
+++ b/docs/tools/audit-depth-control-v3.md
@@ -1,0 +1,113 @@
+# 監査深度コントロール v3
+
+## 原則
+
+```
+自動化できるチェックは全てLayer 0。人間/LLMに渡さない。
+Layer 0を通過しないPRはレビュー対象にならない。
+チェック項目数で制御。「もっとできないか」は禁止。
+```
+
+---
+
+## Layer 0: 自動ゲート（CI/pre-commit/CLIが実行）
+
+全PRに適用。通過しなければレビュー対象にならない。
+
+- tsc --noEmit（型チェック）
+- ESLint（ルール違反0件）
+- テスト全PASS
+- pre-commit checks（console.log、.skip/.only、秘密情報）
+- framework check tests（偽テスト検出）
+- detect-breaking-changes.sh（破壊的変更検出）
+
+Layer 0で自動チェック済みの項目は、Layer 1/2で重複チェックしない。
+
+---
+
+## Layer 1: LLMチェック（LLMベースのGateが担当。6項目固定）
+
+Layer 0通過後のみ。自動化できない意味的判断のみ。
+デフォルトではGate 2（品質スイープ）/Gate 3（敵対的レビュー）が担当。
+組織に応じてレビュアーチェーンの構成は自由（例: lead reviewer → auditor → approver）。
+
+```
+スコープ判断（2項目）:
+  [ ] PR descriptionが変更の意図を正確に表現しているか
+  [ ] 1 PR 1 concern原則に適合しているか
+
+設計整合性（2項目）:
+  [ ] 変更がSSOTの意図と一致しているか
+  [ ] 既存アーキテクチャのパターンと一貫しているか
+
+影響分析（2項目）:
+  [ ] 変更が他のモジュール/サービスに予期しない影響を与えないか
+  [ ] エッジケースが適切に考慮されているか
+```
+
+全てPASS/FAIL/N/Aで埋めたら完了。7項目目を追加する余地はない。
+
+---
+
+## Layer 2: 承認者(approver)判断（該当PRのみ）
+
+水壊的変更 / OSS公開 / セキュリティ変更のみ発動。
+通常PRではLayer 2不要（承認なしでmerge可）。
+承認者の定義はプロジェクトごとに設定（.framework/config.json の approver フィールド）。
+
+---
+
+## PRタイプ別の適用
+
+```
+docs/test/lint/typo:
+  Layer 0のみ → 自動通過すればmerge可
+
+通常の機能追加/バグ修正:
+  Layer 0 + Layer 1（6項目）
+
+破壊的変更/セキュリティ/公開前:
+  Layer 0 + Layer 1（6項目）+ Layer 2（承認者判断）
+```
+
+---
+
+## 修正ループ制御
+
+サイクル上限: 3
+- サイクル1: BLOCKER/CRITICALのみ修正要求
+- サイクル2: 修正確認のみ（新しい指摘は追加しない）
+- サイクル3: 解決しなければエスカレーション
+
+WARNING以下はfollow-up issueに記録。PR内での修正は不要。
+
+---
+
+## 重大度定義
+
+| 重大度 | 定義 | PRでの扱い |
+|--------|------|-----------|
+| BLOCKER | 本番障害 or セキュリティ脆弱性 | 修正必須。マージ不可 |
+| CRITICAL | 機能が正しく動かない | 修正必須。マージ不可 |
+| WARNING | 動作に影響しない | follow-up。マージ可 |
+| INFO | 推奨・スタイル | 記録のみ。マージ可 |
+
+---
+
+## MCP tool統合（v1.1）
+
+```bash
+framework audit-level <PR番号>       # PRタイプからLayer自動判定
+framework audit-checklist <PR番号>   # Layer 1チェックリスト生成
+framework audit-report <PR番号>      # 監査レポート提出（--output json対応）
+```
+
+MCP tool として公開時は、上記コマンドのJSON出力をそのままtool resultとして返す。
+
+---
+
+## 「もっとチェックできないか」が構造的に発生しない理由
+
+- Layer 0は自動。人間の判断余地がない
+- Layer 1は6項目固定。全てPASS/FAIL/N/Aで埋まったら完了
+- Layer 2は該当PRのみ。通常PRでは発動しない

--- a/docs/tools/breaking-change-detection.md
+++ b/docs/tools/breaking-change-detection.md
@@ -1,0 +1,110 @@
+# 破壊的変更検出 — 設計 + スクリプト
+
+## 防ぐもの
+
+PR #164の事故: shared-client fallback削除 → merge → 送信成功率85%→1%崩壊。
+merge前に影響範囲を検証していなかった。
+
+---
+
+## スクリプト: scripts/detect-breaking-changes.sh
+
+```bash
+#!/bin/bash
+set -e
+
+BASE_BRANCH="${1:-main}"
+DIFF=$(git diff "${BASE_BRANCH}"...HEAD 2>/dev/null || git diff "${BASE_BRANCH}"..HEAD)
+FINDINGS=()
+
+# 1. fallback/default/catchall の削除
+if echo "$DIFF" | grep -E '^\-.*\b(fallback|default|catch|else)\b' | grep -v "test" | grep -qv "//"; then
+  FINDINGS+=("fallback/default branch removed — verify all callers")
+fi
+
+# 2. 関数シグネチャの変更
+if echo "$DIFF" | grep -E '^\-.*function\s+\w+\(' | grep -qv "test"; then
+  FINDINGS+=("Function signature changed — verify all call sites")
+fi
+
+# 3. export の削除
+if echo "$DIFF" | grep -E '^\-.*export\s+(function|const|class|interface|type)\s+' | grep -qv "test"; then
+  FINDINGS+=("Exported symbol removed — verify all importers")
+fi
+
+# 4. 環境変数の削除
+if echo "$DIFF" | grep -E '^\-.*process\.env\.\w+' | grep -qv "test"; then
+  FINDINGS+=("Environment variable removed — verify all deployments")
+fi
+
+# 5. DBスキーマ DROP
+if echo "$DIFF" | grep -qE '^\-.*DROP\s+(TABLE|COLUMN)|^\-.*ALTER\s+TABLE.*DROP'; then
+  FINDINGS+=("DB schema DROP — verify migration safety + rollback plan")
+fi
+
+# 6. APIエンドポイント削除
+if echo "$DIFF" | grep -E '^\-.*\.(get|post|put|patch|delete)\s*\(' | grep -qv "test"; then
+  FINDINGS+=("API endpoint removed — verify all clients")
+fi
+
+# 7. 共有リソースの削除
+if echo "$DIFF" | grep -E '^\-.*shared|^\-.*global|^\-.*singleton' | grep -qv "test"; then
+  FINDINGS+=("Shared/global resource removed — verify all consumers")
+fi
+
+if [ ${#FINDINGS[@]} -eq 0 ]; then
+  echo "✅ No breaking change patterns detected."
+  exit 0
+fi
+
+echo ""
+echo "🔴 Breaking change patterns detected:"
+echo ""
+for f in "${FINDINGS[@]}"; do
+  echo "  - $f"
+done
+echo ""
+echo "merge前に:"
+echo "  1. 影響を受ける全コンシューマーを特定"
+echo "  2. 各コンシューマーで動作確認"
+echo "  3. 検証結果をPRコメントに記録"
+echo "  4. 'breaking-change-verified' ラベル付与後にmerge"
+exit 1
+```
+
+---
+
+## CI workflow: .github/workflows/breaking-change-check.yml
+
+```yaml
+name: Breaking Change Check
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect breaking changes
+        run: bash scripts/detect-breaking-changes.sh
+```
+
+検出時: `breaking-change-verified` ラベルなしでmerge不可。
+
+---
+
+## 配置対象
+
+- agent-comms-mcp
+- ai-dev-framework
+- haishin-puls-hub
+- 今後の全リポジトリ
+
+---
+
+## 監査深度の設計
+
+audit-depth-control-v3.md を参照。Layer 0/1/2の定義はそちらが正。

--- a/docs/tools/preflight-check-design.md
+++ b/docs/tools/preflight-check-design.md
@@ -1,0 +1,87 @@
+# プリフライトチェック機構 — 設計
+
+## 目的
+
+実装者（人間/AI問わず）が必読資料を実際に読んだことを決定論的に検証する。
+自己申告ではなく、ファイルへの物理的アクセスの証拨を出力する。
+
+## 仕組み
+
+1. タスクごとに「必読ファイル一覧」をJSONで定義（`.framework/required-reading.json`）
+2. 実装者は作業前に `bash scripts/preflight-check.sh` を実行（v1.1で `framework preflight` にCLI化）
+3. スクリプトが各ファイルに物理的にアクセスし検証結果を出力:
+   - 行数、サイズ
+   - 先頭行（ファイル識別）
+   - 最終5行のMD5ハッシュ（最後まで読んだ証拨）
+   - キーセクションの存在確認+行番号
+4. レポートを `.framework/preflight/` に保存
+5. 実装者はレポートを承認者(approver)に提示。承認後に作業開始
+
+## 必読リストのフォーマット
+
+```json
+{
+  "task": "タスク名",
+  "files": [
+    {
+      "path": "src/cli/commands/gate.ts",
+      "type": "local",
+      "sections": ["check", "design", "quality"],
+      "reason": "Gate A/B/CのCLIエントリポイント"
+    },
+    {
+      "path": "remote:path/to/spec.md",
+      "type": "remote",
+      "command": "rclone cat",
+      "sections": ["Gate A", "Layer 0"],
+      "reason": "Gate AのSSOT定義"
+    }
+  ]
+}
+```
+
+### typeフィールド
+- `local`: ローカルファイル。`cat` で読む
+- `remote`: 外部ストレージ。`command` フィールドで取得コマンドを指定（デフォルト: `rclone cat`）
+
+## レポート出力
+
+### テキスト出力（デフォルト）
+`.framework/preflight/preflight-{日時}.md` にMarkdownレポート
+
+### JSON出力（MCP/CI連携用）
+`--output json` でstdoutにJSON出力:
+
+```json
+{
+  "task": "タスク名",
+  "timestamp": "2026-04-13T12:00:00Z",
+  "files": [
+    {
+      "path": "src/cli/commands/gate.ts",
+      "status": "PASS",
+      "lines": 245,
+      "bytes": 8192,
+      "firstLine": "import { Command } from 'commander';",
+      "lastHash": "a1b2c3d4e5f6...",
+      "sections": {
+        "check": { "found": true, "line": 42 },
+        "design": { "found": true, "line": 78 }
+      }
+    }
+  ],
+  "summary": { "total": 6, "pass": 5, "fail": 1 }
+}
+```
+
+## ADF CLI統合（v1.1）
+
+```bash
+framework preflight                         # .framework/required-reading.json を使用
+framework preflight --output json           # JSON出力（MCP tool対応）
+framework preflight --file custom.json      # カスタムファイル指定
+```
+
+## スクリプト本体
+
+`tools/preflight-check.sh` を参照。

--- a/scripts/detect-breaking-changes.sh
+++ b/scripts/detect-breaking-changes.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# ADF Breaking-change detection
+# Scans `git diff BASE...HEAD` for 7 patterns that historically caused
+# production incidents (PR #164: silent fallback removal → 85%→1% success).
+#
+# Usage:
+#   bash scripts/detect-breaking-changes.sh                 # vs main, text output
+#   bash scripts/detect-breaking-changes.sh origin/main     # custom base
+#   bash scripts/detect-breaking-changes.sh main json       # JSON output (MCP)
+#
+# Exits 0 if clean, 1 if any pattern is detected.
+set -euo pipefail
+
+BASE_BRANCH="${1:-main}"
+OUTPUT_FORMAT="${2:-text}"
+
+# ─────────────────────────────────────────────
+# File-path test exclusion (prior implementation used content-based "grep -qv
+# test" which matched non-test lines in non-test files and silently suppressed
+# findings. Filtering by path is the correct semantics.)
+# ─────────────────────────────────────────────
+CHANGED_RAW=$(
+  git diff --name-only "${BASE_BRANCH}...HEAD" 2>/dev/null \
+    || git diff --name-only "${BASE_BRANCH}..HEAD"
+)
+
+NON_TEST_FILES=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.test.* | *.spec.* | */__tests__/* | */__mocks__/* | tests/* | test/* )
+      continue ;;
+    * )
+      NON_TEST_FILES+=("$f") ;;
+  esac
+done <<< "$CHANGED_RAW"
+
+emit_json() {
+  # $1 = status, remaining args = findings (one per arg)
+  local status="$1"
+  shift
+  printf '{"status":"%s","findings":[' "$status"
+  local i=0
+  local msg
+  for msg in "$@"; do
+    [ "$i" -gt 0 ] && printf ','
+    # Escape double quotes defensively.
+    msg="${msg//\"/\\\"}"
+    printf '"%s"' "$msg"
+    i=$((i+1))
+  done
+  printf '],"count":%d}\n' "$#"
+}
+
+if [ ${#NON_TEST_FILES[@]} -eq 0 ]; then
+  if [ "$OUTPUT_FORMAT" = "json" ]; then
+    emit_json "clean"
+  else
+    echo "✅ No breaking change patterns detected (only test files changed or no changes)."
+  fi
+  exit 0
+fi
+
+DIFF=$(
+  git diff "${BASE_BRANCH}...HEAD" -- "${NON_TEST_FILES[@]}" 2>/dev/null \
+    || git diff "${BASE_BRANCH}..HEAD" -- "${NON_TEST_FILES[@]}"
+)
+
+# Only consider removed source lines (start with a single '-' but not '---'),
+# skip pure comment removals so harmless doc deletions don't trip the scanner.
+removed_lines() {
+  echo "$DIFF" \
+    | grep -E '^-' \
+    | grep -vE '^-{3}' \
+    | grep -vE '^-[[:space:]]*(//|#)'
+}
+
+FINDINGS=()
+
+if removed_lines | grep -qE '\b(fallback|default|catch|else)\b'; then
+  FINDINGS+=("fallback/default branch removed — verify all callers")
+fi
+if removed_lines | grep -qE 'function[[:space:]]+\w+[[:space:]]*\('; then
+  FINDINGS+=("Function signature changed — verify all call sites")
+fi
+if removed_lines | grep -qE 'export[[:space:]]+(function|const|class|interface|type)[[:space:]]+'; then
+  FINDINGS+=("Exported symbol removed — verify all importers")
+fi
+if removed_lines | grep -qE 'process\.env\.\w+'; then
+  FINDINGS+=("Environment variable removed — verify all deployments")
+fi
+if removed_lines | grep -qE 'DROP[[:space:]]+(TABLE|COLUMN)|ALTER[[:space:]]+TABLE.*DROP'; then
+  FINDINGS+=("DB schema DROP — verify migration safety + rollback plan")
+fi
+if removed_lines | grep -qE '\.(get|post|put|patch|delete)[[:space:]]*\('; then
+  FINDINGS+=("API endpoint removed — verify all clients")
+fi
+if removed_lines | grep -qE '\b(shared|global|singleton)\b'; then
+  FINDINGS+=("Shared/global resource removed — verify all consumers")
+fi
+
+if [ ${#FINDINGS[@]} -eq 0 ]; then
+  if [ "$OUTPUT_FORMAT" = "json" ]; then
+    emit_json "clean"
+  else
+    echo "✅ No breaking change patterns detected."
+  fi
+  exit 0
+fi
+
+if [ "$OUTPUT_FORMAT" = "json" ]; then
+  emit_json "detected" "${FINDINGS[@]}"
+  exit 1
+fi
+
+echo ""
+echo "🔴 Breaking change patterns detected:"
+echo ""
+for f in "${FINDINGS[@]}"; do
+  echo "  - $f"
+done
+echo ""
+echo "Before merge:"
+echo "  1. Identify all affected consumers"
+echo "  2. Verify behavior in each consumer"
+echo "  3. Record verification in PR comment"
+echo "  4. Add 'breaking-change-verified' label before merge"
+exit 1

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# ADF Pre-flight Reading Verification
+# 必読資料を実際に読んだことを決定論的に検証する
+set -e
+
+READING_LIST="${1:-.framework/required-reading.json}"
+REPORT_DIR=".framework/preflight"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+OUTPUT_FORMAT="${2:-text}"
+
+if [ ! -f "$READING_LIST" ]; then
+  echo "❌ required-reading.json not found: $READING_LIST" >&2
+  exit 1
+fi
+
+mkdir -p "$REPORT_DIR"
+REPORT="$REPORT_DIR/preflight-$(date +%Y%m%d-%H%M%S).md"
+
+TASK=$(python3 -c "import json; print(json.load(open('$READING_LIST')).get('task','unknown'))" 2>/dev/null || echo "unknown")
+
+if [ "$OUTPUT_FORMAT" = "text" ]; then
+  cat > "$REPORT" << HEADER
+# Pre-flight Reading Report
+
+Generated: $TIMESTAMP
+Task: $TASK
+
+## Results
+
+HEADER
+fi
+
+python3 << PYEOF >> ${OUTPUT_FORMAT:+$([ "$OUTPUT_FORMAT" = "text" ] && echo "$REPORT" || echo "/dev/stdout")}
+import json, subprocess, hashlib, os, sys
+
+data = json.load(open('$READING_LIST'))
+output_format = '$OUTPUT_FORMAT'
+results = []
+
+for f in data.get('files', []):
+    path = f['path']
+    ftype = f.get('type', 'local')
+    sections = f.get('sections', [])
+    reason = f.get('reason', '')
+    command = f.get('command', 'rclone cat')
+
+    content = ''
+    error_msg = ''
+    try:
+        if ftype == 'remote':
+            cmd_parts = command.split() + [path]
+            result = subprocess.run(cmd_parts, capture_output=True, text=True, timeout=30)
+            content = result.stdout
+            if result.returncode != 0:
+                error_msg = result.stderr.strip()[:200]
+        else:
+            if os.path.exists(path):
+                with open(path, 'r', errors='replace') as fh:
+                    content = fh.read()
+            else:
+                error_msg = 'File not found'
+    except Exception as e:
+        error_msg = str(e)[:200]
+
+    file_result = {
+        'path': path,
+        'reason': reason,
+        'status': 'FAIL',
+        'error': error_msg
+    }
+
+    if not content:
+        results.append(file_result)
+        continue
+
+    lines = content.split('\n')
+    line_count = len(lines)
+    byte_count = len(content.encode('utf-8'))
+    first_line = lines[0][:80] if lines else ''
+    last_5 = '\n'.join(lines[-5:]) if len(lines) >= 5 else content
+    last_hash = hashlib.md5(last_5.encode('utf-8')).hexdigest()
+
+    section_results = {}
+    all_found = True
+    for section in sections:
+        found_lines = [i+1 for i, l in enumerate(lines) if section.lower() in l.lower()]
+        section_results[section] = {'found': bool(found_lines), 'line': found_lines[0] if found_lines else None}
+        if not found_lines:
+            all_found = False
+
+    status = 'PASS' if (all_found or not sections) else 'PARTIAL'
+    file_result.update({
+        'status': status,
+        'lines': line_count,
+        'bytes': byte_count,
+        'firstLine': first_line,
+        'lastHash': last_hash,
+        'sections': section_results,
+        'error': ''
+    })
+    results.append(file_result)
+
+summary = {
+    'total': len(results),
+    'pass': sum(1 for r in results if r['status'] in ('PASS', 'PARTIAL')),
+    'fail': sum(1 for r in results if r['status'] == 'FAIL')
+}
+
+if output_format == 'json':
+    output = {'task': data.get('task',''), 'timestamp': '$TIMESTAMP', 'files': results, 'summary': summary}
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+else:
+    for r in results:
+        print(f"---\n\n### {r['path']}")
+        print(f"Reason: {r['reason']}\n")
+        if r['status'] == 'FAIL':
+            err = r.get('error', 'unknown')
+            print(f"- Status: ❌ **FAIL** ({err})\n")
+            continue
+        print(f"- Lines: {r['lines']}")
+        print(f"- Size: {r['bytes']} bytes")
+        print(f"- First line: \`{r['firstLine']}\`")
+        print(f"- Last 5 lines hash: \`{r['lastHash']}\`")
+        if r.get('sections'):
+            print("- Key sections:")
+            for sec, info in r['sections'].items():
+                if info['found']:
+                    print(f"  - ✅ \`{sec}\` — found (line {info['line']})")
+                else:
+                    print(f"  - ❌ \`{sec}\` — **not found**")
+        print(f"- Status: {'✅ PASS' if r['status'] == 'PASS' else '⚠️ PARTIAL'}\n")
+
+    print("---\n\n## Summary\n")
+    print(f"| Item | Value |")
+    print(f"|------|-------|")
+    print(f"| Files | {summary['total']} |")
+    print(f"| Pass | {summary['pass']} |")
+    print(f"| Fail | {summary['fail']} |")
+    print(f"| Timestamp | $TIMESTAMP |")
+    print(f"\n**Present this report to the approver before starting implementation.**")
+PYEOF
+
+if [ "$OUTPUT_FORMAT" = "text" ]; then
+  echo ""
+  cat "$REPORT"
+  echo ""
+  echo "Report saved: $REPORT"
+fi

--- a/templates/project/.framework/required-reading.json.example
+++ b/templates/project/.framework/required-reading.json.example
@@ -1,0 +1,18 @@
+{
+  "task": "Example task — replace with your own",
+  "files": [
+    {
+      "path": "docs/design/SSOT-0_PRD.md",
+      "type": "local",
+      "sections": ["Overview", "Goals"],
+      "reason": "Product requirements"
+    },
+    {
+      "path": "remote:path/to/external-spec.md",
+      "type": "remote",
+      "command": "rclone cat",
+      "sections": ["Key section"],
+      "reason": "External design doc pulled from shared storage"
+    }
+  ]
+}

--- a/templates/project/.github/workflows/breaking-change-check.yml
+++ b/templates/project/.github/workflows/breaking-change-check.yml
@@ -1,0 +1,36 @@
+name: Breaking Change Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect breaking changes
+        id: detect
+        run: |
+          # Compare against the PR base ref (not always 'main' literal).
+          BASE="${{ github.event.pull_request.base.ref }}"
+          bash scripts/detect-breaking-changes.sh "origin/${BASE}"
+
+      - name: Require breaking-change-verified label
+        if: failure() && steps.detect.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes('breaking-change-verified')) {
+              core.setFailed(
+                "Breaking change patterns detected. " +
+                "Verify all affected consumers and add the " +
+                "'breaking-change-verified' label before merge."
+              );
+            } else {
+              core.info("Breaking change patterns detected but verification label present — allowing.");
+            }

--- a/templates/project/scripts/detect-breaking-changes.sh
+++ b/templates/project/scripts/detect-breaking-changes.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# ADF Breaking-change detection
+# Scans `git diff BASE...HEAD` for 7 patterns that historically caused
+# production incidents (PR #164: silent fallback removal → 85%→1% success).
+#
+# Usage:
+#   bash scripts/detect-breaking-changes.sh                 # vs main, text output
+#   bash scripts/detect-breaking-changes.sh origin/main     # custom base
+#   bash scripts/detect-breaking-changes.sh main json       # JSON output (MCP)
+#
+# Exits 0 if clean, 1 if any pattern is detected.
+set -euo pipefail
+
+BASE_BRANCH="${1:-main}"
+OUTPUT_FORMAT="${2:-text}"
+
+# ─────────────────────────────────────────────
+# File-path test exclusion (prior implementation used content-based "grep -qv
+# test" which matched non-test lines in non-test files and silently suppressed
+# findings. Filtering by path is the correct semantics.)
+# ─────────────────────────────────────────────
+CHANGED_RAW=$(
+  git diff --name-only "${BASE_BRANCH}...HEAD" 2>/dev/null \
+    || git diff --name-only "${BASE_BRANCH}..HEAD"
+)
+
+NON_TEST_FILES=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.test.* | *.spec.* | */__tests__/* | */__mocks__/* | tests/* | test/* )
+      continue ;;
+    * )
+      NON_TEST_FILES+=("$f") ;;
+  esac
+done <<< "$CHANGED_RAW"
+
+emit_json() {
+  # $1 = status, remaining args = findings (one per arg)
+  local status="$1"
+  shift
+  printf '{"status":"%s","findings":[' "$status"
+  local i=0
+  local msg
+  for msg in "$@"; do
+    [ "$i" -gt 0 ] && printf ','
+    # Escape double quotes defensively.
+    msg="${msg//\"/\\\"}"
+    printf '"%s"' "$msg"
+    i=$((i+1))
+  done
+  printf '],"count":%d}\n' "$#"
+}
+
+if [ ${#NON_TEST_FILES[@]} -eq 0 ]; then
+  if [ "$OUTPUT_FORMAT" = "json" ]; then
+    emit_json "clean"
+  else
+    echo "✅ No breaking change patterns detected (only test files changed or no changes)."
+  fi
+  exit 0
+fi
+
+DIFF=$(
+  git diff "${BASE_BRANCH}...HEAD" -- "${NON_TEST_FILES[@]}" 2>/dev/null \
+    || git diff "${BASE_BRANCH}..HEAD" -- "${NON_TEST_FILES[@]}"
+)
+
+# Only consider removed source lines (start with a single '-' but not '---'),
+# skip pure comment removals so harmless doc deletions don't trip the scanner.
+removed_lines() {
+  echo "$DIFF" \
+    | grep -E '^-' \
+    | grep -vE '^-{3}' \
+    | grep -vE '^-[[:space:]]*(//|#)'
+}
+
+FINDINGS=()
+
+if removed_lines | grep -qE '\b(fallback|default|catch|else)\b'; then
+  FINDINGS+=("fallback/default branch removed — verify all callers")
+fi
+if removed_lines | grep -qE 'function[[:space:]]+\w+[[:space:]]*\('; then
+  FINDINGS+=("Function signature changed — verify all call sites")
+fi
+if removed_lines | grep -qE 'export[[:space:]]+(function|const|class|interface|type)[[:space:]]+'; then
+  FINDINGS+=("Exported symbol removed — verify all importers")
+fi
+if removed_lines | grep -qE 'process\.env\.\w+'; then
+  FINDINGS+=("Environment variable removed — verify all deployments")
+fi
+if removed_lines | grep -qE 'DROP[[:space:]]+(TABLE|COLUMN)|ALTER[[:space:]]+TABLE.*DROP'; then
+  FINDINGS+=("DB schema DROP — verify migration safety + rollback plan")
+fi
+if removed_lines | grep -qE '\.(get|post|put|patch|delete)[[:space:]]*\('; then
+  FINDINGS+=("API endpoint removed — verify all clients")
+fi
+if removed_lines | grep -qE '\b(shared|global|singleton)\b'; then
+  FINDINGS+=("Shared/global resource removed — verify all consumers")
+fi
+
+if [ ${#FINDINGS[@]} -eq 0 ]; then
+  if [ "$OUTPUT_FORMAT" = "json" ]; then
+    emit_json "clean"
+  else
+    echo "✅ No breaking change patterns detected."
+  fi
+  exit 0
+fi
+
+if [ "$OUTPUT_FORMAT" = "json" ]; then
+  emit_json "detected" "${FINDINGS[@]}"
+  exit 1
+fi
+
+echo ""
+echo "🔴 Breaking change patterns detected:"
+echo ""
+for f in "${FINDINGS[@]}"; do
+  echo "  - $f"
+done
+echo ""
+echo "Before merge:"
+echo "  1. Identify all affected consumers"
+echo "  2. Verify behavior in each consumer"
+echo "  3. Record verification in PR comment"
+echo "  4. Add 'breaking-change-verified' label before merge"
+exit 1


### PR DESCRIPTION
## Summary

Adds two framework-level automation tools plus governance-flow updates to address:

- **Problem 1**: Bots self-report "read the spec" without actually accessing files → deterministic preflight verification.
- **Problem 2**: PR #164 incident — silent fallback removal → merge → send success rate 85% → 1% — detect 7 breaking-change patterns from diff before merge.

## Changes

### 1. Preflight check (`scripts/preflight-check.sh`)
Reads `.framework/required-reading.json`, verifies each file (line count, size, first line, last-5-line MD5, key-section presence), saves report to `.framework/preflight/`, and supports `--output json` (positional arg 2) for MCP tool integration.

- `type: "local"` / `type: "remote"` with pluggable `command` field (default `rclone cat`)
- Error messages preserved in report (no more silent `except: content = ''`)
- Approver-agnostic (no org-specific role names)

### 2. Breaking-change detection (`scripts/detect-breaking-changes.sh` + CI workflow)
Scans `git diff BASE...HEAD` for 7 historical incident patterns:
1. `fallback` / `default` / `catch` / `else` removal
2. Function signature change
3. `export` symbol removal
4. `process.env.*` removal
5. DB schema `DROP TABLE/COLUMN` / `ALTER TABLE … DROP`
6. API endpoint removal (`.get/.post/.put/.patch/.delete`)
7. `shared` / `global` / `singleton` resource removal

**Quality fixes** over the Drive v2 script:
- Path-based test exclusion (prior `grep -qv "test"` was content-based and almost always returned true for non-test files)
- Comment-only removal filtered out so harmless doc deletions don't trip the scanner
- JSON output mode for MCP
- Returns exit 1 on detection → CI blocks merge unless `breaking-change-verified` label is present

### 3. Governance: Layer 0 / 1 / 2 (`~/.claude/rules/governance-flow.md`)
Adds an orthogonal check-depth model to the existing 4-layer review chain:
- **4-layer chain** = *who* reviews (dev → lead → auditor → CTO → CEO)
- **Layer 0/1/2** = *what* is checked (automated / LLM semantic / approver)
- Explicitly: Layer 0-passed items are not re-checked by later chain layers.

### 4. Templates (`templates/project/**`)
`required-reading.json.example`, `detect-breaking-changes.sh`, `breaking-change-check.yml` for distribution to new projects.

## Scope

- ai-dev-framework only in this PR. Distribution to agent-comms-mcp / haishin-puls-hub is a follow-up dispatch (per task spec).
- `framework preflight` / `framework audit-*` CLI commands deferred to v1.1.
- No CLAUDE.md changes.

## Route

`route:fast-merge` — additive tooling, no public API or schema change.

## Test plan

- [x] preflight self-test: PASS=2 / FAIL=1 with error message recorded, JSON parse confirms `pass=2, fail=1`
- [x] detect seeded test: 4/7 patterns detected, test-only diff returns clean, self-scan of this PR's diff returns clean (pure adds)
- [x] governance-flow.md: 10 × "Layer 0" matches, existing 4-layer chain text intact, `breaking-change-verified` label documented
- [x] Unit tests: 1432 pass / 5 pre-existing feedback/auto-feedback flakes (non-touching, same as PR #54)
- [ ] CI: breaking-change-check workflow runs green on this PR (pure-add diff)
- [ ] CI: existing ci.yml / final-audit / auto-merge / merge-notify unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)