### PR TITLE
fix(hooks-installer): add ESM __dirname shim

### DIFF
--- a/src/cli/lib/hooks-installer.ts
+++ b/src/cli/lib/hooks-installer.ts
@@ -7,6 +7,11 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ESM __dirname shim (this module runs as ESM under NodeNext).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // ─────────────────────────────────────────────
 // Constants


### PR DESCRIPTION
## Summary
- `hooks-installer.ts` が NodeNext ESM で動作中に `__dirname is not defined` で throw し、`framework update` の step [5/7] (hooks install) が失敗していた
- `framework-fetch.ts` で既に採用されている `import.meta.url` / `fileURLToPath` pattern を同ファイルにも適用
- Unit tests 61 件全 pass（変更なし）

## Reproduction
Pre-fix:
\`\`\`
$ framework update /path/to/project
[5/7] Updating hooks (skill-tracker + pre-code-gate)...
error  __dirname is not defined
\`\`\`

Post-fix:
\`\`\`
$ framework update /path/to/project
[5/7] Updating hooks (skill-tracker + pre-code-gate)...
+ Updated 6 hook files
[6/7] ...
[7/7] Update complete.
\`\`\`

## Scope
- 1 file, +5 lines (ESM __dirname shim のみ)
- runtime behavior: hooks install path が resolve 可能になる以外の変更なし
- `framework-fetch.ts` と同一 pattern (既存コードに準拠)

## Test plan
- [x] `vitest run src/cli/lib/hooks-installer.test.ts` 61 pass
- [x] 実 repo (agent-comms-mcp) で `framework update` が step [7/7] まで完走することを確認
- [ ] CI green 確認
- [ ] Layer 1 (codex-auditor) 意味判断

## Route
`route:fast-merge` — bug fix、公開 API 変更なし、依存追加なし、scope 狭小。

## Links
- related: PR #55 (preflight + detect-breaking-changes)
- repro target: ~/Developer/agent-comms-mcp (framework update で実証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)