### PR TITLE
fix(ci): breaking-change-check workflow — label override が機能していない

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -14,13 +14,13 @@ jobs:
 
       - name: Detect breaking changes
         id: detect
+        continue-on-error: true
         run: |
-          # Compare against the PR base ref (not always 'main' literal).
           BASE="${{ github.event.pull_request.base.ref }}"
           bash scripts/detect-breaking-changes.sh "origin/${BASE}"
 
-      - name: Require breaking-change-verified label
-        if: failure() && steps.detect.outcome == 'failure'
+      - name: Enforce breaking-change-verified label
+        if: steps.detect.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -32,5 +32,8 @@ jobs:
                 "'breaking-change-verified' label before merge."
               );
             } else {
-              core.info("Breaking change patterns detected but verification label present — allowing.");
+              core.info(
+                "Breaking change patterns detected but 'breaking-change-verified' " +
+                "label is present — verification confirmed by reviewer."
+              );
             }


### PR DESCRIPTION
## Summary
PR #57 で顕在化した CI workflow のバグ修正。`breaking-change-verified` ラベルを付与しても job が fail のままになる問題を解消。

## 問題（PR #55 の実装欠陥）

```yaml
# Before
- name: Detect breaking changes
  run: bash scripts/detect-breaking-changes.sh ...    ← exit 1 で step failed

- name: Require label
  if: failure()
  # core.info() しても job は failed のまま（GitHub Actions 仕様）
```

`if: failure()` の step が成功しても、先行 step の failed は覆らない。結果 label override が機能せず、governance-flow.md §Layer 0「CI green 必須」を満たせない。

## 修正

`continue-on-error: true` で detect step の失敗を job 結果から切り離し、後続 step で `steps.detect.outcome` と label を照合して最終判定。

```yaml
- name: Detect breaking changes
  id: detect
  continue-on-error: true
  run: bash scripts/detect-breaking-changes.sh ...

- name: Enforce breaking-change-verified label
  if: steps.detect.outcome == 'failure'
  # label なし → setFailed, label あり → info (job green)
```

## 方針 (a) vs (b) 比較

| 方針 | 内容 | 判定 |
|---|---|---|
| (a) `continue-on-error: true` + 後続 step で判定 | ✅ 採用 | 最小差分 / 関心事の分離 / UI 可視性 |
| (b) shell 内で GitHub API 叩いて label まで判定 | ❌ | workflow の関心事が script に漏れる |

## Scope（厳格）

- 変更: `.github/workflows/breaking-change-check.yml` **1ファイルのみ**
- 非対象: `scripts/detect-breaking-changes.sh` / `docs/tools/*` / governance-flow.md

## Test plan

- [x] 純粋 add 差分 PR → detect pass → label step skip → job green（既存挙動維持）
- [ ] fallback 削除 diff + label なし → job fail（merge 前に要検証）
- [ ] fallback 削除 diff + label あり → job green（PR #57 で検証）

## Route
`route:fast-merge`（CI 設定のみ。DB / API / 依存追加なし）

## Follow-up
- PR #57: 本 PR merge 後 CI rerun で green 化 → merge
- 別 PR: `scripts/detect-breaking-changes.sh` に `.md` 除外追加（false positive 削減）