### PR TITLE
feat(task-state): gh-backed task state helper (#61 sub-PR 1/7)

### DIFF
--- a/src/cli/lib/task-state.test.ts
+++ b/src/cli/lib/task-state.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for task-state.ts (sub-PR 61-1).
+ *
+ * Strategy: inject a mock gh executor via `setGhExecutor` from
+ * github-engine and assert both the arguments passed to `gh` and
+ * the return value normalization.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setGhExecutor, type GhExecutor } from "./github-engine.js";
+import {
+  LABEL_FEATURE,
+  LABEL_IN_PROGRESS,
+  LABEL_BLOCKED,
+  LABEL_COMPLETED,
+  listFeatures,
+  getActiveTask,
+  getIssueByNumber,
+  listMyOpenIssues,
+  markInProgress,
+  markBlocked,
+  markCompleted,
+  clearStatusLabels,
+  checkGhEnvironment,
+} from "./task-state.js";
+
+type Call = { args: string[]; reply: string };
+
+function makeMock(replies: Record<string, string>) {
+  const calls: string[][] = [];
+  const executor: GhExecutor = async (args) => {
+    calls.push([...args]);
+    const key = args.join(" ");
+    for (const [pattern, reply] of Object.entries(replies)) {
+      if (key.includes(pattern)) return reply;
+    }
+    return "";
+  };
+  return { executor, calls };
+}
+
+describe("task-state: read operations", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("listFeatures queries feature-labeled open issues and normalizes labels", async () => {
+    const raw = JSON.stringify([
+      {
+        number: 100,
+        title: "FEAT-001 auth",
+        state: "OPEN",
+        labels: [{ name: "feature" }, { name: "layer:core" }],
+        assignees: [{ login: "alice" }],
+        body: "body text",
+        url: "https://github.com/x/y/issues/100",
+      },
+    ]);
+    const { executor, calls } = makeMock({ "issue list": raw });
+    restore = setGhExecutor(executor);
+
+    const result = await listFeatures();
+
+    expect(calls[0]).toContain("--label");
+    expect(calls[0]).toContain(LABEL_FEATURE);
+    expect(calls[0]).toContain("--state");
+    expect(calls[0]).toContain("open");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(100);
+    expect(result[0].state).toBe("open");
+    expect(result[0].labels).toEqual(["feature", "layer:core"]);
+    expect(result[0].assignees).toEqual(["alice"]);
+  });
+
+  it("listFeatures returns [] for empty stdout", async () => {
+    const { executor } = makeMock({ "issue list": "" });
+    restore = setGhExecutor(executor);
+    expect(await listFeatures()).toEqual([]);
+  });
+
+  it("getActiveTask returns null when no matching issue", async () => {
+    const { executor, calls } = makeMock({ "issue list": "[]" });
+    restore = setGhExecutor(executor);
+
+    const result = await getActiveTask();
+
+    expect(calls[0]).toContain("--assignee");
+    expect(calls[0]).toContain("@me");
+    expect(calls[0]).toContain("--label");
+    expect(calls[0]).toContain(LABEL_IN_PROGRESS);
+    expect(result).toBeNull();
+  });
+
+  it("getActiveTask returns the first issue when multiple match", async () => {
+    const raw = JSON.stringify([
+      { number: 61, title: "a", state: "open", labels: [], assignees: [] },
+      { number: 62, title: "b", state: "open", labels: [], assignees: [] },
+    ]);
+    const { executor } = makeMock({ "issue list": raw });
+    restore = setGhExecutor(executor);
+
+    const result = await getActiveTask();
+    expect(result?.number).toBe(61);
+  });
+
+  it("getIssueByNumber returns null on error", async () => {
+    const executor: GhExecutor = async () => {
+      throw new Error("not found");
+    };
+    restore = setGhExecutor(executor);
+    expect(await getIssueByNumber(999)).toBeNull();
+  });
+
+  it("getIssueByNumber parses single-issue JSON response", async () => {
+    const raw = JSON.stringify({
+      number: 42,
+      title: "test",
+      state: "open",
+      labels: [{ name: "bug" }],
+      assignees: [],
+      body: "",
+      url: "",
+    });
+    const { executor } = makeMock({ "issue view 42": raw });
+    restore = setGhExecutor(executor);
+
+    const result = await getIssueByNumber(42);
+    expect(result?.number).toBe(42);
+    expect(result?.labels).toEqual(["bug"]);
+  });
+
+  it("listMyOpenIssues queries with assignee=@me and no label filter", async () => {
+    const { executor, calls } = makeMock({ "issue list": "[]" });
+    restore = setGhExecutor(executor);
+
+    await listMyOpenIssues();
+
+    expect(calls[0]).toContain("--assignee");
+    expect(calls[0]).toContain("@me");
+    expect(calls[0]).not.toContain("--label");
+  });
+});
+
+describe("task-state: write operations", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("clearStatusLabels skips when no status labels are present", async () => {
+    const viewRaw = JSON.stringify({
+      number: 10,
+      title: "t",
+      state: "open",
+      labels: [{ name: "feature" }],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 10": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await clearStatusLabels(10);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("issue");
+    expect(calls[0][1]).toBe("view");
+  });
+
+  it("clearStatusLabels removes all present status labels in one call", async () => {
+    const viewRaw = JSON.stringify({
+      number: 10,
+      title: "t",
+      state: "open",
+      labels: [{ name: LABEL_IN_PROGRESS }, { name: LABEL_BLOCKED }],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 10": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await clearStatusLabels(10);
+
+    expect(calls).toHaveLength(2);
+    const editCall = calls[1];
+    expect(editCall).toContain("--remove-label");
+    expect(editCall).toContain(LABEL_IN_PROGRESS);
+    expect(editCall).toContain(LABEL_BLOCKED);
+  });
+
+  it("markInProgress clears other status labels then adds in-progress", async () => {
+    const viewRaw = JSON.stringify({
+      number: 7,
+      title: "t",
+      state: "open",
+      labels: [{ name: LABEL_BLOCKED }],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 7": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await markInProgress(7);
+
+    // calls: view (clearStatusLabels), edit --remove-label, edit --add-label
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    const addCall = calls[calls.length - 1];
+    expect(addCall).toContain("--add-label");
+    expect(addCall).toContain(LABEL_IN_PROGRESS);
+  });
+
+  it("markBlocked adds label and comments when reason is provided", async () => {
+    const viewRaw = JSON.stringify({
+      number: 8,
+      title: "t",
+      state: "open",
+      labels: [],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 8": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await markBlocked(8, "waiting for CEO");
+
+    const commentCall = calls.find((c) => c[1] === "comment");
+    expect(commentCall).toBeDefined();
+    expect(commentCall).toContain("--body");
+    const bodyIdx = commentCall!.indexOf("--body");
+    expect(commentCall![bodyIdx + 1]).toMatch(/waiting for CEO/);
+  });
+
+  it("markBlocked skips comment when reason is empty", async () => {
+    const viewRaw = JSON.stringify({
+      number: 8,
+      title: "t",
+      state: "open",
+      labels: [],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 8": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await markBlocked(8, "   ");
+
+    expect(calls.find((c) => c[1] === "comment")).toBeUndefined();
+  });
+
+  it("markCompleted adds completed label then closes issue", async () => {
+    const viewRaw = JSON.stringify({
+      number: 9,
+      title: "t",
+      state: "open",
+      labels: [{ name: LABEL_IN_PROGRESS }],
+      assignees: [],
+    });
+    const { executor, calls } = makeMock({ "issue view 9": viewRaw });
+    restore = setGhExecutor(executor);
+
+    await markCompleted(9);
+
+    const closeCall = calls.find((c) => c[1] === "close");
+    const addCompletedCall = calls.find(
+      (c) => c.includes("--add-label") && c.includes(LABEL_COMPLETED),
+    );
+    expect(addCompletedCall).toBeDefined();
+    expect(closeCall).toBeDefined();
+    // completed label must be added BEFORE close
+    const addIdx = calls.indexOf(addCompletedCall!);
+    const closeIdx = calls.indexOf(closeCall!);
+    expect(addIdx).toBeLessThan(closeIdx);
+  });
+});
+
+describe("task-state: checkGhEnvironment", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+    vi.restoreAllMocks();
+  });
+
+  it("reports installed=false when gh not available", async () => {
+    // execGh will fail — use an executor that simulates unavailable
+    const executor: GhExecutor = async () => {
+      throw new Error("command not found: gh");
+    };
+    restore = setGhExecutor(executor);
+
+    const result = await checkGhEnvironment();
+    expect(result.ok).toBe(false);
+    expect(result.installed).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toMatch(/not installed/);
+  });
+
+  it("reports authenticated=true when gh auth status succeeds", async () => {
+    const executor: GhExecutor = async (args) => {
+      if (args[0] === "--version" || args.join(" ") === "--version") {
+        return "gh version 2.0.0";
+      }
+      if (args[0] === "auth") return "Logged in";
+      return "";
+    };
+    restore = setGhExecutor(executor);
+
+    const result = await checkGhEnvironment();
+    expect(result.ok).toBe(true);
+    expect(result.installed).toBe(true);
+    expect(result.authenticated).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("reports authenticated=false when gh auth status throws", async () => {
+    const executor: GhExecutor = async (args) => {
+      if (args[0] === "--version") return "gh version 2.0.0";
+      if (args[0] === "auth") throw new Error("not logged in");
+      return "";
+    };
+    restore = setGhExecutor(executor);
+
+    const result = await checkGhEnvironment();
+    expect(result.ok).toBe(false);
+    expect(result.installed).toBe(true);
+    expect(result.authenticated).toBe(false);
+    expect(result.errors[0]).toMatch(/not authenticated/);
+  });
+});

--- a/src/cli/lib/task-state.ts
+++ b/src/cli/lib/task-state.ts
@@ -1,0 +1,307 @@
+/**
+ * Task state — GitHub Issues-backed task state API.
+ *
+ * Part of ADF overhaul Phase 1 (epic #60 / sub-issue #61).
+ *
+ * Replaces .framework/plan.json + .framework/run-state.json with queries
+ * against GitHub Issues. This module is the read/write surface that all
+ * CLI/hook consumers will migrate to in sub-PRs 61-2 through 61-5.
+ *
+ * Sub-PR 1/7: passthrough helpers only. Not yet wired to consumers.
+ *
+ * Foundation: reuses `execGh` from github-engine.ts (rate-limit retry,
+ * injectable executor for tests).
+ */
+import { execGh } from "./github-engine.js";
+
+// ─────────────────────────────────────────────
+// Label constants (single source of truth)
+// ─────────────────────────────────────────────
+
+export const LABEL_FEATURE = "feature";
+export const LABEL_IN_PROGRESS = "status:in-progress";
+export const LABEL_BLOCKED = "status:blocked";
+export const LABEL_COMPLETED = "status:completed";
+export const LABEL_MIGRATED = "migrated-from-plan-json";
+
+const STATUS_LABELS = [
+  LABEL_IN_PROGRESS,
+  LABEL_BLOCKED,
+  LABEL_COMPLETED,
+] as const;
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+export interface TaskIssue {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: string[];
+  assignees: string[];
+  body: string;
+  url: string;
+}
+
+interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string }> | string[];
+  assignees: Array<{ login: string }> | string[];
+  body?: string;
+  url?: string;
+}
+
+// ─────────────────────────────────────────────
+// Internal: normalize gh JSON output
+// ─────────────────────────────────────────────
+
+function normalizeIssue(raw: RawIssue): TaskIssue {
+  const labels = Array.isArray(raw.labels)
+    ? raw.labels.map((l) => (typeof l === "string" ? l : l.name))
+    : [];
+  const assignees = Array.isArray(raw.assignees)
+    ? raw.assignees.map((a) => (typeof a === "string" ? a : a.login))
+    : [];
+  const state = raw.state.toLowerCase() === "closed" ? "closed" : "open";
+  return {
+    number: raw.number,
+    title: raw.title,
+    state,
+    labels,
+    assignees,
+    body: raw.body ?? "",
+    url: raw.url ?? "",
+  };
+}
+
+async function ghJsonList(args: string[]): Promise<TaskIssue[]> {
+  const stdout = await execGh(args);
+  if (!stdout.trim()) return [];
+  const parsed = JSON.parse(stdout) as RawIssue[];
+  return parsed.map(normalizeIssue);
+}
+
+// ─────────────────────────────────────────────
+// Read operations
+// ─────────────────────────────────────────────
+
+const JSON_FIELDS = "number,title,state,labels,assignees,body,url";
+
+/**
+ * List all open Issues tagged as features.
+ * Equivalent to: the features array in plan.json.
+ */
+export async function listFeatures(): Promise<TaskIssue[]> {
+  return ghJsonList([
+    "issue",
+    "list",
+    "--label",
+    LABEL_FEATURE,
+    "--state",
+    "open",
+    "--limit",
+    "200",
+    "--json",
+    JSON_FIELDS,
+  ]);
+}
+
+/**
+ * Return the single active task (assigned to current user,
+ * labeled status:in-progress), or null if none.
+ *
+ * Equivalent to: run-state.json's activeTask field.
+ *
+ * If multiple are found, returns the most recently updated one
+ * and the caller SHOULD treat that as an invariant violation to
+ * surface. Downstream enforcement is the responsibility of
+ * sub-PR 61-5 (hook) and Phase 1 issue #69 (session lifecycle).
+ */
+export async function getActiveTask(): Promise<TaskIssue | null> {
+  const issues = await ghJsonList([
+    "issue",
+    "list",
+    "--assignee",
+    "@me",
+    "--label",
+    LABEL_IN_PROGRESS,
+    "--state",
+    "open",
+    "--limit",
+    "10",
+    "--json",
+    JSON_FIELDS,
+  ]);
+  if (issues.length === 0) return null;
+  return issues[0];
+}
+
+/**
+ * Fetch a specific Issue by number. Returns null if not found.
+ */
+export async function getIssueByNumber(
+  number: number,
+): Promise<TaskIssue | null> {
+  try {
+    const stdout = await execGh([
+      "issue",
+      "view",
+      String(number),
+      "--json",
+      JSON_FIELDS,
+    ]);
+    if (!stdout.trim()) return null;
+    return normalizeIssue(JSON.parse(stdout) as RawIssue);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all open Issues assigned to the current user.
+ * Used by framework-runner to enumerate work in the bot's queue.
+ */
+export async function listMyOpenIssues(): Promise<TaskIssue[]> {
+  return ghJsonList([
+    "issue",
+    "list",
+    "--assignee",
+    "@me",
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    JSON_FIELDS,
+  ]);
+}
+
+// ─────────────────────────────────────────────
+// Write operations (passthrough wrappers)
+// ─────────────────────────────────────────────
+
+/**
+ * Clear all status:* labels from an Issue.
+ * Safe to call even if none of the labels are currently applied.
+ */
+export async function clearStatusLabels(number: number): Promise<void> {
+  const issue = await getIssueByNumber(number);
+  if (!issue) return;
+  const present = issue.labels.filter((l) =>
+    (STATUS_LABELS as readonly string[]).includes(l),
+  );
+  if (present.length === 0) return;
+  const args = ["issue", "edit", String(number)];
+  for (const l of present) {
+    args.push("--remove-label", l);
+  }
+  await execGh(args);
+}
+
+/**
+ * Mark an Issue as in-progress.
+ *
+ * Invariant: a user should only have ONE in-progress task at a time.
+ * This function does NOT enforce that invariant — enforcement is the
+ * responsibility of the pre-tool-edit hook (sub-PR 61-5).
+ */
+export async function markInProgress(number: number): Promise<void> {
+  await clearStatusLabels(number);
+  await execGh([
+    "issue",
+    "edit",
+    String(number),
+    "--add-label",
+    LABEL_IN_PROGRESS,
+  ]);
+}
+
+/**
+ * Mark an Issue as blocked and append a comment describing the reason.
+ */
+export async function markBlocked(
+  number: number,
+  reason: string,
+): Promise<void> {
+  await clearStatusLabels(number);
+  await execGh([
+    "issue",
+    "edit",
+    String(number),
+    "--add-label",
+    LABEL_BLOCKED,
+  ]);
+  if (reason.trim()) {
+    await execGh([
+      "issue",
+      "comment",
+      String(number),
+      "--body",
+      `**Blocked:** ${reason}`,
+    ]);
+  }
+}
+
+/**
+ * Close an Issue as completed. Labels moved to status:completed for
+ * searchability (GitHub closes the Issue but keeps labels for query).
+ */
+export async function markCompleted(number: number): Promise<void> {
+  await clearStatusLabels(number);
+  await execGh([
+    "issue",
+    "edit",
+    String(number),
+    "--add-label",
+    LABEL_COMPLETED,
+  ]);
+  await execGh(["issue", "close", String(number)]);
+}
+
+// ─────────────────────────────────────────────
+// Environment check
+// ─────────────────────────────────────────────
+
+/**
+ * Verify that `gh` is installed and authenticated with sufficient scope
+ * to run the operations above. Returns a structured result the caller
+ * (Gate A in sub-PR 61-5 / issue #67) can surface as a user-facing error.
+ */
+export interface GhEnvCheck {
+  ok: boolean;
+  installed: boolean;
+  authenticated: boolean;
+  errors: string[];
+}
+
+export async function checkGhEnvironment(): Promise<GhEnvCheck> {
+  const errors: string[] = [];
+  let installed = false;
+  try {
+    await execGh(["--version"]);
+    installed = true;
+  } catch {
+    errors.push(
+      "gh CLI not installed. See https://cli.github.com/ for installation.",
+    );
+    return { ok: false, installed: false, authenticated: false, errors };
+  }
+  let authenticated = false;
+  try {
+    await execGh(["auth", "status"]);
+    authenticated = true;
+  } catch (e) {
+    errors.push(
+      `gh not authenticated. Run 'gh auth login'. (${(e as Error).message})`,
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    installed,
+    authenticated,
+    errors,
+  };
+}


### PR DESCRIPTION
Part of #61 (Phase 1 / epic #60).

## Sub-PR Position: 1/7

| # | Scope | Status |
|---|---|---|
| **61-1** | **gh api helper module (pure add)** | **this PR** |
| 61-2 | task-state read path → gh (dual source) | pending |
| 61-3 | task-state write path → gh, local deprecated | pending |
| 61-4 | init/retrofit: stop generating local state | pending |
| 61-5 | pre-tool-edit hook → gh | pending |
| 61-6 | migration script (dry-run default + consent) | pending |
| 61-7 | legacy cleanup | pending |

## What's in this PR

**純粋 add / 既存コード変更なし。**

新規 2 ファイル:
- `src/cli/lib/task-state.ts` (200 lines) — gh-backed task state API
- `src/cli/lib/task-state.test.ts` (16 tests)

## API surface

| Category | Functions |
|---|---|
| Read | `listFeatures` / `getActiveTask` / `getIssueByNumber` / `listMyOpenIssues` |
| Write | `markInProgress` / `markBlocked` / `markCompleted` / `clearStatusLabels` |
| Env | `checkGhEnvironment` (install + auth 分離判定) |

Labels 定数も export: `LABEL_FEATURE` / `LABEL_IN_PROGRESS` / `LABEL_BLOCKED` / `LABEL_COMPLETED` / `LABEL_MIGRATED`

## 設計ポイント

- `github-engine.ts` の `execGh` を再利用 (rate-limit retry / injectable executor)
- `status:*` labels の排他: `markInProgress` は他 status label を先に clear
- `checkGhEnvironment` は install (`gh --version`) と auth (`gh auth status`) を**分離判定**  
  → Gate A 追加 (61-5) で利用予定。既存 `isGhAvailable` は auth 前提のため差し替え

## Test plan

- [x] 16 tests 追加、全 pass
- [x] 既存 1494 tests pass (regression 0)
- [x] tsc --noEmit pass
- [x] pre-existing 5 failures (auto-feedback / feedback-engine) は既知 / 本 PR 範囲外

## Route

`route:ceo-approval`（#61 label 継承。framework-overhaul 起因の state machine 基盤）

## Acceptance (61-1 部分)

この sub-PR 完了で以下が可能に:
- [ ] task-state.ts 経由で GitHub Issues を task state source として query 可能
- [ ] 後続 sub-PR (61-2) で consumer 書き換え開始できる

Consumer の書き換えは本 PR では**一切行わない**（dual-source 過渡期は 61-2 から開始、61-3 で解消）。