### PR TITLE
feat(task-state): state-reader facade for read path → gh (#61 sub-PR 3/7)

### DIFF
--- a/src/cli/lib/plan-model.ts
+++ b/src/cli/lib/plan-model.ts
@@ -404,6 +404,7 @@ export function assignSeqNumbers(waves: Wave[], tasks: Task[]): void {
 const PLAN_FILE = ".framework/plan.json";
 const PLAN_TMP = ".framework/plan.json.tmp";
 
+/** @deprecated Use loadPlanFromGitHub() from state-reader.ts instead. See #61. */
 export function loadPlan(projectDir: string): PlanState | null {
   const filePath = path.join(projectDir, PLAN_FILE);
   if (!fs.existsSync(filePath)) return null;

--- a/src/cli/lib/run-model.ts
+++ b/src/cli/lib/run-model.ts
@@ -383,6 +383,7 @@ export function calculateProgress(state: RunState): number {
 
 const RUN_STATE_FILE = ".framework/run-state.json";
 
+/** @deprecated Use loadRunStateFromGitHub() from state-reader.ts instead. See #61. */
 export function loadRunState(
   projectDir: string,
 ): RunState | null {

--- a/src/cli/lib/state-reader.test.ts
+++ b/src/cli/lib/state-reader.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  parseAdfMeta,
+  loadPlanFromGitHub,
+  loadRunStateFromGitHub,
+  warnLocalReadDeprecated,
+  resetDeprecationWarning,
+} from "./state-reader.js";
+import { setGhExecutor } from "./github-engine.js";
+
+// ─────────────────────────────────────────────
+// parseAdfMeta tests
+// ─────────────────────────────────────────────
+
+describe("parseAdfMeta", () => {
+  it("extracts valid adf-meta from Issue body", () => {
+    const body = `## FEAT-001: Login
+
+Some description
+
+<!-- adf-meta:begin
+{
+  "version": "1.0",
+  "type": "feature",
+  "id": "FEAT-001",
+  "migratedFrom": "plan.json",
+  "migratedAt": "2026-04-17T00:00:00Z"
+}
+adf-meta:end -->`;
+
+    const meta = parseAdfMeta(body);
+    expect(meta).not.toBeNull();
+    expect(meta!.version).toBe("1.0");
+    expect(meta!.type).toBe("feature");
+    expect(meta!.id).toBe("FEAT-001");
+    expect(meta!.migratedFrom).toBe("plan.json");
+  });
+
+  it("returns null when no marker present", () => {
+    expect(parseAdfMeta("Just a regular Issue body")).toBeNull();
+  });
+
+  it("returns null for malformed JSON in marker", () => {
+    const body = `<!-- adf-meta:begin
+{ invalid json }
+adf-meta:end -->`;
+    expect(parseAdfMeta(body)).toBeNull();
+  });
+
+  it("handles marker with extra whitespace", () => {
+    const body = `<!--  adf-meta:begin
+{"version":"1.0","type":"task","id":"T-1"}
+adf-meta:end  -->`;
+    const meta = parseAdfMeta(body);
+    expect(meta).not.toBeNull();
+    expect(meta!.id).toBe("T-1");
+  });
+});
+
+// ─────────────────────────────────────────────
+// loadPlanFromGitHub tests
+// ─────────────────────────────────────────────
+
+describe("loadPlanFromGitHub", () => {
+  let restoreGh: () => void;
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+  });
+
+  it("returns null when no feature Issues exist", async () => {
+    restoreGh = setGhExecutor(async () => "[]");
+    const plan = await loadPlanFromGitHub();
+    expect(plan).toBeNull();
+  });
+
+  it("converts feature Issues to PlanState", async () => {
+    const issues = [
+      {
+        number: 100,
+        title: "[FEAT-001] User Login",
+        state: "open",
+        labels: [{ name: "feature" }, { name: "P0" }],
+        assignees: [],
+        body: `## FEAT-001: User Login
+
+| Field | Value |
+|---|---|
+| Priority | P0 |
+| Size | M |
+| Type | common |
+| Dependencies | none |
+
+<!-- adf-meta:begin
+{"version":"1.0","type":"feature","id":"FEAT-001","migratedFrom":"plan.json","migratedAt":"2026-04-17T00:00:00Z"}
+adf-meta:end -->`,
+        url: "https://github.com/test/repo/issues/100",
+      },
+      {
+        number: 101,
+        title: "[FEAT-002] Dashboard",
+        state: "open",
+        labels: [{ name: "feature" }, { name: "P1" }],
+        assignees: [],
+        body: `## FEAT-002: Dashboard
+
+| Field | Value |
+|---|---|
+| Priority | P1 |
+| Size | L |
+| Type | proprietary |
+| Dependencies | FEAT-001 |
+
+<!-- adf-meta:begin
+{"version":"1.0","type":"feature","id":"FEAT-002","migratedFrom":"plan.json","migratedAt":"2026-04-17T00:00:00Z"}
+adf-meta:end -->`,
+        url: "https://github.com/test/repo/issues/101",
+      },
+    ];
+
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      if (args.includes("feature")) {
+        return JSON.stringify(issues);
+      }
+      return "[]";
+    });
+
+    const plan = await loadPlanFromGitHub();
+    expect(plan).not.toBeNull();
+    expect(plan!.status).toBe("generated");
+    expect(plan!.waves).toHaveLength(1);
+    expect(plan!.waves[0].features).toHaveLength(2);
+
+    const feat1 = plan!.waves[0].features[0];
+    expect(feat1.id).toBe("FEAT-001");
+    expect(feat1.name).toBe("User Login");
+    expect(feat1.priority).toBe("P0");
+    expect(feat1.size).toBe("M");
+    expect(feat1.type).toBe("common");
+    expect(feat1.dependencies).toEqual([]);
+
+    const feat2 = plan!.waves[0].features[1];
+    expect(feat2.id).toBe("FEAT-002");
+    expect(feat2.dependencies).toEqual(["FEAT-001"]);
+  });
+
+  it("extracts feature data from table when no adf-meta", async () => {
+    const issues = [
+      {
+        number: 200,
+        title: "[FEAT-X] Manual Feature",
+        state: "open",
+        labels: [{ name: "feature" }],
+        assignees: [],
+        body: `## FEAT-X: Manual Feature
+
+| Field | Value |
+|---|---|
+| Priority | P2 |
+| Size | S |
+| Type | proprietary |
+| Dependencies | none |`,
+        url: "https://github.com/test/repo/issues/200",
+      },
+    ];
+
+    restoreGh = setGhExecutor(async () => JSON.stringify(issues));
+
+    const plan = await loadPlanFromGitHub();
+    expect(plan).not.toBeNull();
+    const feat = plan!.waves[0].features[0];
+    expect(feat.id).toBe("FEAT-X");
+    expect(feat.priority).toBe("P2");
+    expect(feat.size).toBe("S");
+  });
+});
+
+// ─────────────────────────────────────────────
+// loadRunStateFromGitHub tests
+// ─────────────────────────────────────────────
+
+describe("loadRunStateFromGitHub", () => {
+  let restoreGh: () => void;
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+  });
+
+  it("returns no active task when none in-progress", async () => {
+    restoreGh = setGhExecutor(async () => "[]");
+
+    const state = await loadRunStateFromGitHub();
+    expect(state.hasActiveTask).toBe(false);
+    expect(state.activeTask).toBeNull();
+    expect(state.openIssueCount).toBe(0);
+  });
+
+  it("returns active task when one exists", async () => {
+    const activeIssue = {
+      number: 50,
+      title: "[FEAT-001-DB] Database",
+      state: "open",
+      labels: [{ name: "status:in-progress" }],
+      assignees: [{ login: "bot" }],
+      body: "task body",
+      url: "https://github.com/test/repo/issues/50",
+    };
+
+    let callCount = 0;
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      callCount++;
+      if (args.includes("status:in-progress")) {
+        return JSON.stringify([activeIssue]);
+      }
+      return JSON.stringify([activeIssue]);
+    });
+
+    const state = await loadRunStateFromGitHub();
+    expect(state.hasActiveTask).toBe(true);
+    expect(state.activeTask).not.toBeNull();
+    expect(state.activeTask!.number).toBe(50);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Deprecation warning tests
+// ─────────────────────────────────────────────
+
+describe("warnLocalReadDeprecated", () => {
+  beforeEach(() => {
+    resetDeprecationWarning();
+  });
+
+  it("warns once then suppresses", () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(msg);
+
+    warnLocalReadDeprecated("test-caller");
+    warnLocalReadDeprecated("test-caller-2");
+
+    console.warn = origWarn;
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("deprecated");
+    expect(warnings[0]).toContain("test-caller");
+  });
+});

--- a/src/cli/lib/state-reader.test.ts
+++ b/src/cli/lib/state-reader.test.ts
@@ -223,6 +223,38 @@ describe("loadRunStateFromGitHub", () => {
 });
 
 // ─────────────────────────────────────────────
+// gh failure tests (facade error surface)
+// ─────────────────────────────────────────────
+
+describe("facade gh failure handling", () => {
+  let restoreGh: () => void;
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+  });
+
+  it("loadPlanFromGitHub returns null on gh CLI error", async () => {
+    restoreGh = setGhExecutor(async () => {
+      throw new Error("gh: auth required");
+    });
+
+    const plan = await loadPlanFromGitHub();
+    expect(plan).toBeNull();
+  });
+
+  it("loadRunStateFromGitHub returns empty state on gh CLI error", async () => {
+    restoreGh = setGhExecutor(async () => {
+      throw new Error("gh: network timeout");
+    });
+
+    const state = await loadRunStateFromGitHub();
+    expect(state.hasActiveTask).toBe(false);
+    expect(state.activeTask).toBeNull();
+    expect(state.openIssueCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────
 // Deprecation warning tests
 // ─────────────────────────────────────────────
 

--- a/src/cli/lib/state-reader.ts
+++ b/src/cli/lib/state-reader.ts
@@ -1,0 +1,160 @@
+/**
+ * State reader — dual-source facade for plan/run state reads.
+ *
+ * Part of ADF overhaul #61 sub-PR 3/7 (read path → GitHub Issues).
+ *
+ * During the dual-source transition period (sub-PR 3 and 4):
+ *   - READ: from GitHub Issues via task-state.ts
+ *   - WRITE: still to local files (removed in sub-PR 4)
+ *
+ * This module provides loadPlan/loadRunState-compatible interfaces
+ * backed by GitHub Issues. Consumers switch imports one at a time.
+ *
+ * After sub-PR 4, local file reads are fully removed.
+ */
+import {
+  listFeatures,
+  getActiveTask,
+  listMyOpenIssues,
+  type TaskIssue,
+} from "./task-state.js";
+import type {
+  PlanState,
+  Feature,
+  Priority,
+  Size,
+  FeatureType,
+} from "./plan-model.js";
+
+// ─────────────────────────────────────────────
+// adf-meta parser (extracts structured data from Issue body)
+// ─────────────────────────────────────────────
+
+interface AdfMeta {
+  version: string;
+  type: "feature" | "task";
+  id: string;
+  migratedFrom?: string;
+  migratedAt?: string;
+  [key: string]: unknown;
+}
+
+const META_REGEX = /<!--\s*adf-meta:begin\s*\n([\s\S]*?)\nadf-meta:end\s*-->/;
+
+export function parseAdfMeta(body: string): AdfMeta | null {
+  const match = META_REGEX.exec(body);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]) as AdfMeta;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────
+// Issue → Feature/Task conversion
+// ─────────────────────────────────────────────
+
+function extractTableValue(body: string, field: string): string {
+  const regex = new RegExp(`\\|\\s*${field}\\s*\\|\\s*([^|]+)\\|`);
+  const match = regex.exec(body);
+  return match ? match[1].trim() : "";
+}
+
+function issueToFeature(issue: TaskIssue): Feature {
+  const meta = parseAdfMeta(issue.body);
+  const id = meta?.id ?? extractIdFromTitle(issue.title);
+
+  const priorityRaw = extractTableValue(issue.body, "Priority");
+  const sizeRaw = extractTableValue(issue.body, "Size");
+  const typeRaw = extractTableValue(issue.body, "Type");
+  const depsRaw = extractTableValue(issue.body, "Dependencies");
+
+  return {
+    id,
+    name: extractNameFromTitle(issue.title),
+    priority: (["P0", "P1", "P2"].includes(priorityRaw) ? priorityRaw : "P2") as Priority,
+    size: (["S", "M", "L", "XL"].includes(sizeRaw) ? sizeRaw : "M") as Size,
+    type: (typeRaw === "common" ? "common" : "proprietary") as FeatureType,
+    dependencies: depsRaw && depsRaw !== "none" ? depsRaw.split(",").map((d) => d.trim()) : [],
+    dependencyCount: 0,
+    ssotFile: extractTableValue(issue.body, "SSOT File") || undefined,
+  };
+}
+
+function extractIdFromTitle(title: string): string {
+  const match = /\[([^\]]+)\]/.exec(title);
+  return match ? match[1] : title;
+}
+
+function extractNameFromTitle(title: string): string {
+  const match = /\]\s*(.+)$/.exec(title);
+  return match ? match[1].trim() : title;
+}
+
+// ─────────────────────────────────────────────
+// GitHub Issues → PlanState adapter
+// ─────────────────────────────────────────────
+
+export async function loadPlanFromGitHub(): Promise<PlanState | null> {
+  const featureIssues = await listFeatures();
+  if (featureIssues.length === 0) return null;
+
+  const features = featureIssues.map(issueToFeature);
+
+  return {
+    status: "generated",
+    generatedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    waves: [
+      {
+        number: 1,
+        phase: "individual",
+        title: "All Features (from GitHub Issues)",
+        features,
+      },
+    ],
+    tasks: [],
+    circularDependencies: [],
+  };
+}
+
+// ─────────────────────────────────────────────
+// GitHub Issues → RunState adapter
+// ─────────────────────────────────────────────
+
+export interface RunStateFromGitHub {
+  hasActiveTask: boolean;
+  activeTask: TaskIssue | null;
+  openIssueCount: number;
+}
+
+export async function loadRunStateFromGitHub(): Promise<RunStateFromGitHub> {
+  const activeTask = await getActiveTask();
+  const openIssues = await listMyOpenIssues();
+
+  return {
+    hasActiveTask: activeTask !== null,
+    activeTask,
+    openIssueCount: openIssues.length,
+  };
+}
+
+// ─────────────────────────────────────────────
+// Deprecation warning for direct local reads
+// ─────────────────────────────────────────────
+
+let _deprecationWarned = false;
+
+export function warnLocalReadDeprecated(caller: string): void {
+  if (_deprecationWarned) return;
+  _deprecationWarned = true;
+  console.warn(
+    `[deprecated] ${caller}: reading from local plan.json/run-state.json. ` +
+      `Migrate to state-reader.ts (GitHub Issues). See #61.`,
+  );
+}
+
+export function resetDeprecationWarning(): void {
+  _deprecationWarned = false;
+}

--- a/src/cli/lib/state-reader.ts
+++ b/src/cli/lib/state-reader.ts
@@ -97,7 +97,12 @@ function extractNameFromTitle(title: string): string {
 // ─────────────────────────────────────────────
 
 export async function loadPlanFromGitHub(): Promise<PlanState | null> {
-  const featureIssues = await listFeatures();
+  let featureIssues: TaskIssue[];
+  try {
+    featureIssues = await listFeatures();
+  } catch {
+    return null;
+  }
   if (featureIssues.length === 0) return null;
 
   const features = featureIssues.map(issueToFeature);
@@ -130,14 +135,22 @@ export interface RunStateFromGitHub {
 }
 
 export async function loadRunStateFromGitHub(): Promise<RunStateFromGitHub> {
-  const activeTask = await getActiveTask();
-  const openIssues = await listMyOpenIssues();
+  try {
+    const activeTask = await getActiveTask();
+    const openIssues = await listMyOpenIssues();
 
-  return {
-    hasActiveTask: activeTask !== null,
-    activeTask,
-    openIssueCount: openIssues.length,
-  };
+    return {
+      hasActiveTask: activeTask !== null,
+      activeTask,
+      openIssueCount: openIssues.length,
+    };
+  } catch {
+    return {
+      hasActiveTask: false,
+      activeTask: null,
+      openIssueCount: 0,
+    };
+  }
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- #61 の sub-PR 3/7: dual-source 開始 — GitHub Issues からの read path facade
- `state-reader.ts` が `loadPlanFromGitHub()` / `loadRunStateFromGitHub()` を提供
- adf-meta hidden marker (sub-PR 2 で埋め込み) をパースして Feature/Task struct に復元
- `loadPlan()` / `loadRunState()` に @deprecated 注記追加

## Changes (4 files, +410 lines)

### New
- `src/cli/lib/state-reader.ts` — dual-source facade
  - `parseAdfMeta()`: Issue body から hidden marker 抽出
  - `loadPlanFromGitHub()`: feature Issues → PlanState 変換
  - `loadRunStateFromGitHub()`: active task + open Issue count
  - `warnLocalReadDeprecated()`: 一回限り deprecation 警告
- `src/cli/lib/state-reader.test.ts` — 10 tests

### Modified
- `src/cli/lib/plan-model.ts` — `loadPlan()` に @deprecated JSDoc
- `src/cli/lib/run-model.ts` — `loadRunState()` に @deprecated JSDoc

## Design decisions
- **Consumer 変換は sub-PR 4-5 に分割**: 15+ files / 30+ call sites の一括変換は 1 PR に収まらない
- **Gate B は local reads 維持**: synchronous (pre-commit hook) のため async GitHub API に切替不可。sub-PR 5 (hook 書き換え) で対応
- **adf-meta + table 両対応**: marker があれば id 抽出、なければ Issue body の Markdown table からフォールバック

## Test plan
- [x] 10 new tests pass (parseAdfMeta: 4, loadPlanFromGitHub: 3, loadRunStateFromGitHub: 2, deprecation: 1)
- [x] tsc --noEmit: 0 errors
- [x] 1520 existing tests pass (5 pre-existing failures, unrelated)
- [x] @deprecated annotation が既存テストに影響なし

Ref: #61 (parent Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)