### PR TITLE
feat(task-state): connect write-through + deprecate local generation (#61 sub-PR 5/7)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,8 @@ import { registerImproveCommand } from "./commands/improve.js";
 import { registerIngestCommand } from "./commands/ingest.js";
 import { registerCheckCommand } from "./commands/check.js";
 import { registerMigrateCommand } from "./commands/migrate.js";
+import { setWriteThrough, type RunState } from "./lib/run-model.js";
+import { syncTaskStatusToGitHub, resolveIssueNumber } from "./lib/state-writer.js";
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -97,5 +99,28 @@ registerSessionCommands(program);
 registerConfigCommand(program);
 registerImproveCommand(program);
 registerMigrateCommand(program);
+
+// Connect write-through hook: sync RunState transitions to GitHub Issues (#61)
+setWriteThrough((state: RunState, prev: RunState | null) => {
+  if (!prev) return;
+  for (const task of state.tasks) {
+    const prevTask = prev.tasks.find((t) => t.taskId === task.taskId);
+    const oldStatus = prevTask?.status ?? "backlog";
+    if (oldStatus === task.status) continue;
+
+    resolveIssueNumber(task.taskId).then((issueNumber) => {
+      if (!issueNumber) return;
+      return syncTaskStatusToGitHub({
+        taskId: task.taskId,
+        issueNumber,
+        oldStatus,
+        newStatus: task.status,
+        reason: task.stopDetails ?? task.stopReason,
+      });
+    }).catch(() => {
+      // best-effort
+    });
+  }
+});
 
 program.parse();

--- a/src/cli/lib/plan-engine.ts
+++ b/src/cli/lib/plan-engine.ts
@@ -269,7 +269,7 @@ export async function runPlanEngine(
     }
   }
 
-  // Save plan state
+  // Save plan state (local file — deprecated, use --sync for GitHub Issues)
   const plan: PlanState = {
     status: "generated",
     generatedAt: new Date().toISOString(),
@@ -279,6 +279,9 @@ export async function runPlanEngine(
     circularDependencies: cycles,
   };
   savePlan(projectDir, plan);
+  console.warn(
+    "[deprecated] plan.json written locally. Run 'framework plan --sync' to create GitHub Issues (SSOT). See #61.",
+  );
 
   return { plan, errors };
 }

--- a/src/cli/lib/plan-model.ts
+++ b/src/cli/lib/plan-model.ts
@@ -420,6 +420,10 @@ export function loadPlan(projectDir: string): PlanState | null {
 /**
  * Save plan.json with atomic write (tmp + rename) to prevent corruption on crash.
  * Uses the same pattern as sync-engine.ts atomicWritePlan().
+ *
+ * @deprecated Local plan.json is being replaced by GitHub Issues as SSOT.
+ * Use `framework plan --sync` to create GitHub Issues. See #61.
+ * Local file is still written for backward compatibility during transition.
  */
 export function savePlan(projectDir: string, plan: PlanState): void {
   const planFilePath = path.join(projectDir, PLAN_FILE);

--- a/src/cli/lib/run-engine.ts
+++ b/src/cli/lib/run-engine.ts
@@ -122,10 +122,20 @@ export async function runTask(
   // Load or create run state
   let state = loadRunState(projectDir);
   if (!state) {
-    const plan = loadPlan(projectDir);
+    // Try local plan.json first (backward compat), then GitHub Issues
+    let plan = loadPlan(projectDir);
+    if (!plan || plan.waves.length === 0) {
+      // Try loading from GitHub Issues (new SSOT, #61)
+      try {
+        const { loadPlanFromGitHub } = await import("./state-reader.js");
+        plan = await loadPlanFromGitHub();
+      } catch {
+        // state-reader not available — fall through to error
+      }
+    }
     if (!plan || plan.waves.length === 0) {
       errors.push(
-        "No implementation plan found. Run 'framework plan' first.",
+        "No implementation plan found. Run 'framework plan --sync' first.",
       );
       return {
         taskId: "",


### PR DESCRIPTION
## Summary
- #61 の sub-PR 5/7: write-through hook 接続 + local file 生成 deprecation
- PR #77 auditor feedback の「setWriteThrough 未接続」を解決
- `framework run` が plan.json なしでも GitHub Issues から起動可能に

## Changes (4 files, +45 -3)

### src/cli/index.ts — write-through hook 接続
- `setWriteThrough()` を CLI startup で呼出
- `saveRunState()` のたびに task status 変更を GitHub Issues に sync
- `resolveIssueNumber()` → `syncTaskStatusToGitHub()` を fire-and-forget

### src/cli/lib/plan-model.ts — savePlan() @deprecated
- JSDoc @deprecated 追加
- `framework plan --sync` への誘導

### src/cli/lib/plan-engine.ts — deprecation warning
- plan.json 書出時に console.warn で deprecation 通知

### src/cli/lib/run-engine.ts — GitHub Issues fallback
- local plan.json がない場合 `loadPlanFromGitHub()` を dynamic import で試行
- GitHub Issues に feature Issues があれば plan.json なしで `framework run` 可能

## Design decisions
- **Dynamic import**: state-reader.ts の circular dependency 回避
- **Backward compat**: local file はまだ書かれる (cleanup は sub-PR 7)
- **Best-effort sync**: GitHub API 失敗は swallow、local state が authoritative

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 1537 existing tests pass (5 pre-existing failures, unrelated)
- [x] No regressions from write-through connection
- [x] plan-engine deprecation warning は stderr のみ、exit code に影響なし

Ref: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)