### PR TITLE
feat(task-state): pre-code-gate hook → gh issue check (#61 sub-PR 6/7)

### DIFF
--- a/.claude/hooks/pre-code-gate.sh
+++ b/.claude/hooks/pre-code-gate.sh
@@ -118,6 +118,7 @@ fi
 
 task_check=$(node -e "
   const fs = require('fs');
+  const { execSync } = require('child_process');
   try {
     const pf = '$project_dir/.framework/project.json';
     if (fs.existsSync(pf)) {
@@ -125,6 +126,13 @@ task_check=$(node -e "
       const pt = p.profileType || p.type || '';
       if (pt === 'lp' || pt === 'hp') { console.log('SKIP'); process.exit(0); }
     }
+    // Primary: check GitHub Issues for active task (#61)
+    try {
+      const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
+      const issues = JSON.parse(out);
+      if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); process.exit(0); }
+    } catch { /* gh not available or error — fall through to local */ }
+    // Fallback: local run-state.json (deprecated, #61)
     const rf = '$project_dir/.framework/run-state.json';
     if (!fs.existsSync(rf)) { console.log('NO_STATE'); process.exit(0); }
     const s = JSON.parse(fs.readFileSync(rf, 'utf8'));
@@ -146,7 +154,8 @@ case "$task_check" in
     echo "  ACTIVE TASK REQUIRED" >&2
     echo "=====================================" >&2
     echo "  Gates passed, but no task is in progress." >&2
-    echo "  Start a task first:" >&2
+    echo "  Start a task via GitHub Issue or local command:" >&2
+    echo "    gh issue edit <num> --add-label status:in-progress" >&2
     echo "    framework run <taskId>" >&2
     echo "" >&2
     echo "  Emergency bypass:" >&2

--- a/templates/hooks/pre-code-gate.sh
+++ b/templates/hooks/pre-code-gate.sh
@@ -118,6 +118,7 @@ fi
 
 task_check=$(node -e "
   const fs = require('fs');
+  const { execSync } = require('child_process');
   try {
     const pf = '$project_dir/.framework/project.json';
     if (fs.existsSync(pf)) {
@@ -125,6 +126,13 @@ task_check=$(node -e "
       const pt = p.profileType || p.type || '';
       if (pt === 'lp' || pt === 'hp') { console.log('SKIP'); process.exit(0); }
     }
+    // Primary: check GitHub Issues for active task (#61)
+    try {
+      const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
+      const issues = JSON.parse(out);
+      if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); process.exit(0); }
+    } catch { /* gh not available or error — fall through to local */ }
+    // Fallback: local run-state.json (deprecated, #61)
     const rf = '$project_dir/.framework/run-state.json';
     if (!fs.existsSync(rf)) { console.log('NO_STATE'); process.exit(0); }
     const s = JSON.parse(fs.readFileSync(rf, 'utf8'));
@@ -146,7 +154,8 @@ case "$task_check" in
     echo "  ACTIVE TASK REQUIRED" >&2
     echo "=====================================" >&2
     echo "  Gates passed, but no task is in progress." >&2
-    echo "  Start a task first:" >&2
+    echo "  Start a task via GitHub Issue or local command:" >&2
+    echo "    gh issue edit <num> --add-label status:in-progress" >&2
     echo "    framework run <taskId>" >&2
     echo "" >&2
     echo "  Emergency bypass:" >&2


### PR DESCRIPTION
## Summary
- #61 の sub-PR 6/7: pre-code-gate hook の Active Task Check を GitHub Issues に切替
- `gh issue list --assignee @me --label status:in-progress` で active task を検出
- gh 不在/エラー時は local run-state.json にフォールバック (backward compat)

## Changes (2 files, +20 -2)
- `.claude/hooks/pre-code-gate.sh` — active hook
- `templates/hooks/pre-code-gate.sh` — template for retrofit

## Active Task Check フロー (変更後)
```
1. Primary: gh issue list --label status:in-progress (5s timeout)
   → Issue found → ACTIVE → allow edit
   → gh not available → fall through to step 2
2. Fallback: .framework/run-state.json (deprecated)
   → currentTaskId or tasks[].status === 'in_progress'
3. Neither → ACTIVE TASK REQUIRED → block edit (exit 2)
```

## Design decisions
- **5s timeout on gh**: pre-commit hook は速度が重要。gh が遅い場合は local fallback
- **Silent fallthrough**: gh error は stderr を suppress (`stdio: ['pipe','pipe','pipe']`)
- **Backward compat**: local run-state.json fallback は sub-PR 7 (cleanup) まで維持
- **Template + active hook 両方更新**: retrofit で新規プロジェクトにも配布

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 1537 existing tests pass (5 pre-existing failures, unrelated)
- [x] Hook script syntax valid (bash -n check)
- [x] gh unavailable → graceful fallback to local file

Ref: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)