### PR TITLE
chore(task-state): remove legacy local-file fallbacks (#61 sub-PR 7/7)

### DIFF
--- a/.claude/hooks/pre-code-gate.sh
+++ b/.claude/hooks/pre-code-gate.sh
@@ -126,22 +126,12 @@ task_check=$(node -e "
       const pt = p.profileType || p.type || '';
       if (pt === 'lp' || pt === 'hp') { console.log('SKIP'); process.exit(0); }
     }
-    // Primary: check GitHub Issues for active task (#61)
-    try {
-      const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
-      const issues = JSON.parse(out);
-      if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); process.exit(0); }
-    } catch { /* gh not available or error — fall through to local */ }
-    // Fallback: local run-state.json (deprecated, #61)
-    const rf = '$project_dir/.framework/run-state.json';
-    if (!fs.existsSync(rf)) { console.log('NO_STATE'); process.exit(0); }
-    const s = JSON.parse(fs.readFileSync(rf, 'utf8'));
-    if (s.currentTaskId) { console.log('ACTIVE:' + s.currentTaskId); }
-    else {
-      const t = (s.tasks || []).find(t => t.status === 'in_progress');
-      console.log(t ? 'ACTIVE:' + t.taskId : 'NO_TASK');
-    }
-  } catch { console.log('ERROR'); }
+    // Check GitHub Issues for active task (SSOT, #61)
+    const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
+    const issues = JSON.parse(out);
+    if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); }
+    else { console.log('NO_TASK'); }
+  } catch { console.log('NO_STATE'); }
 ")
 
 case "$task_check" in
@@ -154,9 +144,8 @@ case "$task_check" in
     echo "  ACTIVE TASK REQUIRED" >&2
     echo "=====================================" >&2
     echo "  Gates passed, but no task is in progress." >&2
-    echo "  Start a task via GitHub Issue or local command:" >&2
+    echo "  Start a task via GitHub Issue:" >&2
     echo "    gh issue edit <num> --add-label status:in-progress" >&2
-    echo "    framework run <taskId>" >&2
     echo "" >&2
     echo "  Emergency bypass:" >&2
     echo "    FRAMEWORK_SKIP_TASK_CHECK=1" >&2

--- a/src/cli/lib/plan-engine.ts
+++ b/src/cli/lib/plan-engine.ts
@@ -279,9 +279,6 @@ export async function runPlanEngine(
     circularDependencies: cycles,
   };
   savePlan(projectDir, plan);
-  console.warn(
-    "[deprecated] plan.json written locally. Run 'framework plan --sync' to create GitHub Issues (SSOT). See #61.",
-  );
 
   return { plan, errors };
 }

--- a/src/cli/lib/run-engine.ts
+++ b/src/cli/lib/run-engine.ts
@@ -122,16 +122,17 @@ export async function runTask(
   // Load or create run state
   let state = loadRunState(projectDir);
   if (!state) {
-    // Try local plan.json first (backward compat), then GitHub Issues
-    let plan = loadPlan(projectDir);
+    // Primary: GitHub Issues (SSOT, #61)
+    let plan = null;
+    try {
+      const { loadPlanFromGitHub } = await import("./state-reader.js");
+      plan = await loadPlanFromGitHub();
+    } catch {
+      // state-reader not available — try local fallback
+    }
+    // Fallback: local plan.json (legacy)
     if (!plan || plan.waves.length === 0) {
-      // Try loading from GitHub Issues (new SSOT, #61)
-      try {
-        const { loadPlanFromGitHub } = await import("./state-reader.js");
-        plan = await loadPlanFromGitHub();
-      } catch {
-        // state-reader not available — fall through to error
-      }
+      plan = loadPlan(projectDir);
     }
     if (!plan || plan.waves.length === 0) {
       errors.push(

--- a/templates/hooks/pre-code-gate.sh
+++ b/templates/hooks/pre-code-gate.sh
@@ -126,22 +126,12 @@ task_check=$(node -e "
       const pt = p.profileType || p.type || '';
       if (pt === 'lp' || pt === 'hp') { console.log('SKIP'); process.exit(0); }
     }
-    // Primary: check GitHub Issues for active task (#61)
-    try {
-      const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
-      const issues = JSON.parse(out);
-      if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); process.exit(0); }
-    } catch { /* gh not available or error — fall through to local */ }
-    // Fallback: local run-state.json (deprecated, #61)
-    const rf = '$project_dir/.framework/run-state.json';
-    if (!fs.existsSync(rf)) { console.log('NO_STATE'); process.exit(0); }
-    const s = JSON.parse(fs.readFileSync(rf, 'utf8'));
-    if (s.currentTaskId) { console.log('ACTIVE:' + s.currentTaskId); }
-    else {
-      const t = (s.tasks || []).find(t => t.status === 'in_progress');
-      console.log(t ? 'ACTIVE:' + t.taskId : 'NO_TASK');
-    }
-  } catch { console.log('ERROR'); }
+    // Check GitHub Issues for active task (SSOT, #61)
+    const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
+    const issues = JSON.parse(out);
+    if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); }
+    else { console.log('NO_TASK'); }
+  } catch { console.log('NO_STATE'); }
 ")
 
 case "$task_check" in
@@ -154,9 +144,8 @@ case "$task_check" in
     echo "  ACTIVE TASK REQUIRED" >&2
     echo "=====================================" >&2
     echo "  Gates passed, but no task is in progress." >&2
-    echo "  Start a task via GitHub Issue or local command:" >&2
+    echo "  Start a task via GitHub Issue:" >&2
     echo "    gh issue edit <num> --add-label status:in-progress" >&2
-    echo "    framework run <taskId>" >&2
     echo "" >&2
     echo "  Emergency bypass:" >&2
     echo "    FRAMEWORK_SKIP_TASK_CHECK=1" >&2


### PR DESCRIPTION
## Summary
- #61 の sub-PR 7/7 (最終): legacy local-file コード削除
- run-state.json fallback をhook から除去
- GitHub Issues を primary、local plan.json を fallback に優先順位反転
- Closes #61

## Changes (4 files, +24 -48)

### pre-code-gate.sh (active + template)
- run-state.json fallback コード削除 (-20 lines)
- GitHub Issues のみで active task を判定
- gh failure → `NO_STATE` (graceful)

### plan-engine.ts
- deprecated console.warn 削除 (transition notice 不要に)

### run-engine.ts
- 優先順位反転: GitHub Issues → local plan.json (was: local → GitHub)

## #61 全 sub-PR 完了サマリー

| Sub-PR | PR | Scope | Status |
|---|---|---|---|
| 1/7 | #70 | gh API helper module | ✅ merged |
| 2/7 | #75 | migration script (plan.json → Issues) | ✅ merged |
| 3/7 | #76 | state-reader facade (read path) | ✅ merged |
| 4/7 | #77 | state-writer (write-through) | ✅ merged |
| 5/7 | #78 | write-through 接続 + deprecation | ✅ merged |
| 6/7 | #79 | pre-code-gate hook → gh | ✅ merged |
| 7/7 | #80 | legacy cleanup (this PR) | 🔵 review |

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 1537 existing tests pass (5 pre-existing failures, unrelated)
- [x] No regressions
- [x] Hook script syntax valid

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)