### PR TITLE
fix(migrate): handle legacy plan.json schema

### DIFF
--- a/src/cli/lib/migrate-engine.test.ts
+++ b/src/cli/lib/migrate-engine.test.ts
@@ -231,6 +231,26 @@ describe("analyzeMigration", () => {
     expect(report.toCreate).toHaveLength(3);
   });
 
+  it("handles legacy schema (features[] without waves[])", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adf-migrate-"));
+    const frameworkDir = path.join(tmpDir, ".framework");
+    fs.mkdirSync(frameworkDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(frameworkDir, "plan.json"),
+      JSON.stringify({
+        version: "1.0.0",
+        features: [{ id: "F-001", name: "Test", status: "done" }],
+      }),
+    );
+
+    const report = analyzeMigration(tmpDir);
+    expect(report.planFile.exists).toBe(true);
+    expect(report.planFile.featureCount).toBe(1);
+    expect(report.toSkip).toHaveLength(1);
+    expect(report.toSkip[0].reason).toContain("incompatible schema");
+    expect(report.errors).toHaveLength(0);
+  });
+
   it("handles malformed plan.json gracefully", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "adf-migrate-"));
     const frameworkDir = path.join(tmpDir, ".framework");

--- a/src/cli/lib/migrate-engine.ts
+++ b/src/cli/lib/migrate-engine.ts
@@ -180,8 +180,25 @@ export function analyzeMigration(projectDir: string, alreadyMigrated: string[] =
       const raw = fs.readFileSync(planPath, "utf-8");
       const plan = JSON.parse(raw) as PlanState;
 
-      const features = plan.waves.flatMap((w) => w.features);
+      // Handle legacy schema (features[] instead of waves[].features[])
+      const legacyPlan = plan as unknown as { features?: unknown[] };
+      const features = plan.waves
+        ? plan.waves.flatMap((w) => w.features)
+        : [];
       const tasks = plan.tasks ?? [];
+
+      if (!plan.waves && legacyPlan.features) {
+        report.planFile.featureCount = legacyPlan.features.length;
+        report.planFile.taskCount = 0;
+        report.planFile.isEmpty = legacyPlan.features.length === 0;
+        report.toSkip.push({
+          type: "feature",
+          id: "*",
+          title: "Legacy schema (features[] without waves[])",
+          reason: "incompatible schema — manual migration required",
+        });
+        return report;
+      }
       report.planFile.featureCount = features.length;
       report.planFile.taskCount = tasks.length;
       report.planFile.isEmpty = isPlanEmpty(plan);


### PR DESCRIPTION
## Summary
- #61 post-merge 検証で発見: iyasaka の legacy plan.json (features[] without waves[]) で crash
- defensive handling を追加: legacy schema は「incompatible — manual migration required」と報告

## Changes (2 files, +38 -1)
- `src/cli/lib/migrate-engine.ts` — legacy schema detection + graceful skip
- `src/cli/lib/migrate-engine.test.ts` — +1 test (legacy schema handling)

## Test plan
- [x] 17 migrate-engine tests pass (+1 new)
- [x] iyasaka dry-run: crash → graceful skip report
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)