### PR TITLE
fix(hooks): update hooks-installer to use GitHub Issues (#61 post-merge)

### DIFF
--- a/src/cli/lib/hooks-installer.ts
+++ b/src/cli/lib/hooks-installer.ts
@@ -142,6 +142,7 @@ fi
 
 task_check=$(node -e "
   const fs = require('fs');
+  const { execSync } = require('child_process');
   try {
     const pf = '$project_dir/.framework/project.json';
     if (fs.existsSync(pf)) {
@@ -149,15 +150,12 @@ task_check=$(node -e "
       const pt = p.profileType || p.type || '';
       if (pt === 'lp' || pt === 'hp') { console.log('SKIP'); process.exit(0); }
     }
-    const rf = '$project_dir/.framework/run-state.json';
-    if (!fs.existsSync(rf)) { console.log('NO_STATE'); process.exit(0); }
-    const s = JSON.parse(fs.readFileSync(rf, 'utf8'));
-    if (s.currentTaskId) { console.log('ACTIVE:' + s.currentTaskId); }
-    else {
-      const t = (s.tasks || []).find(t => t.status === 'in_progress');
-      console.log(t ? 'ACTIVE:' + t.taskId : 'NO_TASK');
-    }
-  } catch { console.log('ERROR'); }
+    // Check GitHub Issues for active task (SSOT, #61)
+    const out = execSync('gh issue list --assignee @me --label status:in-progress --state open --json number,title --limit 1', { timeout: 5000, encoding: 'utf8', stdio: ['pipe','pipe','pipe'] });
+    const issues = JSON.parse(out);
+    if (issues.length > 0) { console.log('ACTIVE:' + issues[0].title); }
+    else { console.log('NO_TASK'); }
+  } catch { console.log('NO_STATE'); }
 ")
 
 case "$task_check" in
@@ -170,8 +168,8 @@ case "$task_check" in
     echo "  ACTIVE TASK REQUIRED" >&2
     echo "=====================================" >&2
     echo "  Gates passed, but no task is in progress." >&2
-    echo "  Start a task first:" >&2
-    echo "    framework run <taskId>" >&2
+    echo "  Start a task via GitHub Issue:" >&2
+    echo "    gh issue edit <num> --add-label status:in-progress" >&2
     echo "" >&2
     echo "  Emergency bypass:" >&2
     echo "    FRAMEWORK_SKIP_TASK_CHECK=1" >&2

--- a/src/cli/lib/pre-code-gate-hook.test.ts
+++ b/src/cli/lib/pre-code-gate-hook.test.ts
@@ -17,9 +17,13 @@ function runHook(
   envOverrides?: Record<string, string>,
 ): { exitCode: number; stderr: string } {
   const input = JSON.stringify(toolInput);
+  const mockBinDir = path.join(tmpDir, "bin");
   const env = {
     ...process.env,
     CLAUDE_PROJECT_DIR: tmpDir,
+    PATH: fs.existsSync(mockBinDir)
+      ? `${mockBinDir}:${process.env.PATH}`
+      : process.env.PATH,
     ...envOverrides,
   };
 
@@ -53,36 +57,23 @@ function writeGatesPassed(): void {
   );
 }
 
-/** Helper: write run-state.json with an active task */
-function writeRunStateWithActiveTask(taskId: string): void {
-  const dir = path.join(tmpDir, ".framework");
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(
-    path.join(dir, "run-state.json"),
-    JSON.stringify({
-      status: "running",
-      currentTaskId: taskId,
-      tasks: [{ taskId, status: "in_progress" }],
-      startedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    }),
-  );
+/** Helper: create a mock gh script that returns specified Issues */
+function setupMockGh(issues: { number: number; title: string }[]): void {
+  const binDir = path.join(tmpDir, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const script = `#!/bin/bash\necho '${JSON.stringify(issues)}'`;
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, script, { mode: 0o755 });
 }
 
-/** Helper: write run-state.json with no active task */
+/** Helper: simulate active task via mock gh (returns in-progress Issue) */
+function writeRunStateWithActiveTask(taskId: string): void {
+  setupMockGh([{ number: 1, title: `[${taskId}] Active Task` }]);
+}
+
+/** Helper: simulate no active task via mock gh (returns empty list) */
 function writeRunStateIdle(): void {
-  const dir = path.join(tmpDir, ".framework");
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(
-    path.join(dir, "run-state.json"),
-    JSON.stringify({
-      status: "idle",
-      currentTaskId: null,
-      tasks: [{ taskId: "FEAT-001-DB", status: "done" }],
-      startedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    }),
-  );
+  setupMockGh([]);
 }
 
 /** Helper: write project.json with profile type */
@@ -163,7 +154,7 @@ describe("pre-code-gate.sh hook", () => {
     const result = runHook(editSrcInput);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toContain("ACTIVE TASK REQUIRED");
-    expect(result.stderr).toContain("framework run");
+    expect(result.stderr).toContain("gh issue edit");
   });
 
   it("allows when gates passed AND task in_progress", () => {
@@ -202,40 +193,20 @@ describe("pre-code-gate.sh hook", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("detects active task via currentTaskId only", () => {
+  it("detects active task via GitHub Issue label", () => {
     writeGatesPassed();
-    const dir = path.join(tmpDir, ".framework");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, "run-state.json"),
-      JSON.stringify({
-        status: "running",
-        currentTaskId: "FEAT-002-API",
-        tasks: [],
-      }),
-    );
+    setupMockGh([{ number: 42, title: "[FEAT-002-API] API Implementation" }]);
 
     const result = runHook(editSrcInput);
     expect(result.exitCode).toBe(0);
   });
 
-  it("detects active task via task status only", () => {
+  it("blocks when gh returns empty issue list", () => {
     writeGatesPassed();
-    const dir = path.join(tmpDir, ".framework");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, "run-state.json"),
-      JSON.stringify({
-        status: "running",
-        currentTaskId: null,
-        tasks: [
-          { taskId: "FEAT-001-DB", status: "done" },
-          { taskId: "FEAT-001-API", status: "in_progress" },
-        ],
-      }),
-    );
+    setupMockGh([]);
 
     const result = runHook(editSrcInput);
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("ACTIVE TASK REQUIRED");
   });
 });


### PR DESCRIPTION
## Summary
- hooks-installer.ts の hardcoded hook template が旧 run-state.json 参照のままだった
- `framework retrofit` で配布される hook が GitHub Issues 未対応だった問題を修正
- テストも mock gh script 方式に更新

## Root cause
sub-PR 6/7 で `.claude/hooks/` と `templates/hooks/` は更新したが、
`hooks-installer.ts` 内の hardcoded template を更新し忘れた。
iyasaka retrofit で発覚。

## Changes (2 files, +33 -64)
- `src/cli/lib/hooks-installer.ts` — Active Task Check を gh issue list に更新
- `src/cli/lib/pre-code-gate-hook.test.ts` — mock gh script 方式に更新 (11/11 pass)

## Test plan
- [x] 11 hook tests pass
- [x] tsc clean
- [x] iyasaka retrofit で正しい hook が配布されることを確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)