### PR TITLE
feat(gates): consumers → check runs, gates.json deprecated (#62 sub-PR 3/4)

### DIFF
--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -172,14 +172,21 @@ export function registerGateCommand(program: Command): void {
         state = result.state;
         logger.header("Pre-Code Gate Status (from GitHub Actions check runs)");
       } else {
-        state = loadGateState(projectDir);
-        if (!state) {
-          logger.info(
-            "No gate state found. Run 'framework gate check' or use --check-runs.",
-          );
-          return;
+        // Default: try check runs first, fallback to local gates.json (#62)
+        const autoResult = await loadGateStatusFromCheckRuns();
+        if (autoResult.state) {
+          state = autoResult.state;
+          logger.header("Pre-Code Gate Status (from GitHub Actions)");
+        } else {
+          state = loadGateState(projectDir);
+          if (!state) {
+            logger.info(
+              "No gate state found. Run 'framework gate check' or configure Gate workflows.",
+            );
+            return;
+          }
+          logger.header("Pre-Code Gate Status (from local gates.json, deprecated)");
         }
-        logger.header("Pre-Code Gate Status");
       }
 
       logger.info("");
@@ -198,12 +205,18 @@ export function registerGateCommand(program: Command): void {
       }
     });
 
-  // framework gate reset
+  // framework gate reset (deprecated — gates are now managed by GitHub Actions check runs)
   gate
     .command("reset")
-    .description("Reset all gates to pending")
+    .description("Reset all gates to pending (deprecated: use GitHub Actions re-run instead)")
     .action(async () => {
       const projectDir = process.cwd();
+
+      console.warn(
+        "[deprecated] 'framework gate reset' resets local gates.json only. " +
+        "Gates are now managed by GitHub Actions check runs. " +
+        "To re-run gates, push a new commit or re-run workflows in GitHub. See #62.",
+      );
 
       let state = loadGateState(projectDir);
       if (!state) {
@@ -212,7 +225,7 @@ export function registerGateCommand(program: Command): void {
       resetGateState(state);
       saveGateState(projectDir, state);
 
-      logger.success("All gates reset to pending.");
+      logger.success("All gates reset to pending (local only).");
       logger.info(
         "Run 'framework gate check' to re-evaluate.",
       );

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -48,7 +48,7 @@ export function registerStatusCommand(program: Command): void {
         }
 
         const io = createStatusTerminalIO();
-        const result = collectStatus(projectDir);
+        const result = await collectStatus(projectDir);
 
         // Enrich tasks from GitHub if sync state exists
         if (result.tasks.length > 0 || options.github) {
@@ -70,7 +70,7 @@ export function registerStatusCommand(program: Command): void {
               io.print(`  GitHub writeback: ${wb.updated} tasks updated${wb.created ? " (run-state.json created)" : ""}`);
             }
             // Re-collect to show updated state
-            const refreshed = collectStatus(projectDir);
+            const refreshed = await collectStatus(projectDir);
             result.currentPhase = refreshed.currentPhase;
             result.phaseLabel = refreshed.phaseLabel;
             result.overallProgress = refreshed.overallProgress;

--- a/src/cli/lib/gate-model.ts
+++ b/src/cli/lib/gate-model.ts
@@ -161,6 +161,7 @@ export function updateGateC(
   };
 }
 
+/** @deprecated Gate reset is not applicable with check runs. See #62. */
 export function resetGateState(state: GateState): void {
   const now = new Date().toISOString();
   state.gateA = { status: "pending", checks: [], checkedAt: now };
@@ -225,6 +226,7 @@ export function buildAllGatesResult(state: GateState): AllGatesResult {
 
 const GATE_STATE_FILE = ".framework/gates.json";
 
+/** @deprecated Use loadGateStatusFromCheckRuns() for GitHub Actions check runs. See #62. */
 export function loadGateState(
   projectDir: string,
 ): GateState | null {
@@ -256,6 +258,7 @@ function migrateLegacyChecks(checks: GateCheck[] | undefined): void {
   }
 }
 
+/** @deprecated Gate state is now managed by GitHub Actions check runs. See #62. */
 export function saveGateState(
   projectDir: string,
   state: GateState,

--- a/src/cli/lib/status-engine.test.ts
+++ b/src/cli/lib/status-engine.test.ts
@@ -40,15 +40,15 @@ describe("status-engine", () => {
   });
 
   describe("collectStatus", () => {
-    it("returns zeroed status for fresh project", () => {
-      const result = collectStatus(tmpDir);
+    it("returns zeroed status for fresh project", async () => {
+      const result = await collectStatus(tmpDir);
       expect(result.overallProgress).toBe(0);
       expect(result.documents).toHaveLength(0);
       expect(result.tasks).toHaveLength(0);
       expect(result.audits).toHaveLength(0);
     });
 
-    it("detects discover phase", () => {
+    it("detects discover phase", async () => {
       const sessionPath = path.join(
         tmpDir,
         ".framework/discover-session.json",
@@ -59,12 +59,12 @@ describe("status-engine", () => {
         "utf-8",
       );
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       const discovery = result.phases.find((p) => p.label === "Discovery");
       expect(discovery?.status).toBe("active");
     });
 
-    it("detects completed discover phase", () => {
+    it("detects completed discover phase", async () => {
       const sessionPath = path.join(
         tmpDir,
         ".framework/discover-session.json",
@@ -75,18 +75,18 @@ describe("status-engine", () => {
         "utf-8",
       );
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       const discovery = result.phases.find((p) => p.label === "Discovery");
       expect(discovery?.status).toBe("completed");
     });
 
-    it("collects document statuses from generation state", () => {
+    it("collects document statuses from generation state", async () => {
       const genState = createGenerationState();
       markDocumentGenerated(genState, "docs/idea/IDEA_CANVAS.md", 80);
       markDocumentGenerated(genState, "docs/idea/USER_PERSONA.md", 50);
       saveGenerationState(tmpDir, genState);
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       expect(result.documents.length).toBeGreaterThan(0);
       const canvas = result.documents.find(
         (d) => d.path === "docs/idea/IDEA_CANVAS.md",
@@ -94,7 +94,7 @@ describe("status-engine", () => {
       expect(canvas?.completeness).toBe(80);
     });
 
-    it("collects tasks from run state", () => {
+    it("collects tasks from run state", async () => {
       const state = createRunState();
       state.tasks = [
         {
@@ -108,13 +108,13 @@ describe("status-engine", () => {
       ];
       saveRunState(tmpDir, state);
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       expect(result.tasks).toHaveLength(2);
       expect(result.tasks[0].status).toBe("done");
       expect(result.tasks[1].status).toBe("backlog");
     });
 
-    it("collects current execution health", () => {
+    it("collects current execution health", async () => {
       const state = createRunState();
       state.tasks = [
         {
@@ -134,12 +134,12 @@ describe("status-engine", () => {
       state.currentTaskId = "T1";
       saveRunState(tmpDir, state);
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       expect(result.execution?.taskId).toBe("T1");
       expect(result.execution?.expired).toBe(false);
     });
 
-    it("collects recent audit reports", () => {
+    it("collects recent audit reports", async () => {
       saveAuditReport(tmpDir, {
         mode: "ssot",
         target: {
@@ -156,13 +156,13 @@ describe("status-engine", () => {
         findings: [],
       });
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       expect(result.audits).toHaveLength(1);
       expect(result.audits[0].score).toBe(97);
       expect(result.audits[0].verdict).toBe("pass");
     });
 
-    it("calculates overall progress", () => {
+    it("calculates overall progress", async () => {
       // Add completed discover
       fs.writeFileSync(
         path.join(tmpDir, ".framework/discover-session.json"),
@@ -185,7 +185,7 @@ describe("status-engine", () => {
         circularDependencies: [],
       });
 
-      const result = collectStatus(tmpDir);
+      const result = await collectStatus(tmpDir);
       expect(result.overallProgress).toBeGreaterThan(0);
     });
   });

--- a/src/cli/lib/status-engine.ts
+++ b/src/cli/lib/status-engine.ts
@@ -22,6 +22,7 @@ import { loadAuditReports } from "./audit-model.js";
 import { loadProjectProfile } from "./profile-model.js";
 import {
   loadGateState,
+  loadGateStatusFromCheckRuns,
   type GateStatus,
 } from "./gate-model.js";
 import {
@@ -137,7 +138,7 @@ const PHASES: { number: number; label: string }[] = [
 // Status Aggregation
 // ─────────────────────────────────────────────
 
-export function collectStatus(projectDir: string): StatusResult {
+export async function collectStatus(projectDir: string): Promise<StatusResult> {
   const phases = detectPhases(projectDir);
   const currentPhase = phases.find((p) => p.status === "active");
   const documents = collectDocuments(projectDir);
@@ -162,8 +163,9 @@ export function collectStatus(projectDir: string): StatusResult {
       }
     : null;
 
-  // Load gate state
-  const gateState = loadGateState(projectDir);
+  // Load gate state: try check runs first, fallback to local gates.json (#62)
+  const checkRunResult = await loadGateStatusFromCheckRuns();
+  const gateState = checkRunResult.state ?? loadGateState(projectDir);
   const gates: GateStatusInfo | null = gateState
     ? {
         gateA: gateState.gateA.status,


### PR DESCRIPTION
## Summary
- #62 の sub-PR 3/4: 主要 consumer を check runs 参照に切替、gates.json を deprecated
- `framework status` と `framework gate status` が check runs を primary source に
- `framework gate reset` に deprecation warning 追加

## Changes (5 files, +49 -31)

### Consumer 切替
- **status-engine.ts**: `collectStatus()` を async 化、check runs → local fallback
- **status.ts**: `await collectStatus()` に更新
- **gate.ts**: `gate status` が auto-detect (check runs → local fallback、source をヘッダに表示)

### Deprecation
- **gate-model.ts**: `loadGateState()`, `saveGateState()`, `resetGateState()` に @deprecated
- **gate.ts**: `gate reset` に deprecation warning + メッセージ更新

### テスト更新
- **status-engine.test.ts**: 8 test callbacks を async 化

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 20 affected tests pass (status-engine: 14, gate-checkrun: 6)
- [x] collectStatus async 化で caller が正しく await

Ref: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)