### PR TITLE
chore(gates): remove gate reset + stop auto-creating gates.json (#62 sub-PR 4/4)

### DIFF
--- a/docs/specs/06_CODE_QUALITY.md
+++ b/docs/specs/06_CODE_QUALITY.md
@@ -483,12 +483,33 @@ Gate Dのステータスは `.framework/gates.json` に他のGateと同様に管
 
 #### Gateシステム全体像
 
+> **v1.1.0 改訂** (#62): Gate A/B/C は GitHub Actions check runs で管理。
+> `.framework/gates.json` は local cache (pre-commit hook 用) で、SSOT ではない。
+
 | Gate | 目的 | 実行タイミング | 強制方法 |
 |---|---|---|---|
-| A（Environment） | 環境が壊れた状態でコードを書かせない | pre-commit / CI | スマートブロッキング |
-| B（Planning） | 計画なしに場当たり的な実装をさせない | pre-commit / CI | スマートブロッキング |
-| C（SSOT） | 仕様未承認のままコードを書かせない | pre-commit / CI | スマートブロッキング |
+| A（Environment） | 環境が壊れた状態でコードを書かせない | **PR check run** + pre-commit hook | `gate-a.yml` + branch protection |
+| B（Planning） | 計画なしに場当たり的な実装をさせない | **PR check run** + pre-commit hook | `gate-b.yml` + branch protection |
+| C（SSOT） | 仕様未承認のままコードを書かせない | **PR check run** + pre-commit hook | `gate-c.yml` + branch protection |
 | D（Post-Deploy） | デプロイされた環境の動作を検証 | デプロイ後 | CI デプロイジョブ |
+
+#### Branch Protection 設定手順 (adopter 向け)
+
+Gate A/B/C を PR merge の必須条件にするには:
+
+```
+1. GitHub repo Settings → Branches → Branch protection rules
+2. main ブランチのルールを編集 (または新規作成)
+3. "Require status checks to pass before merging" を有効化
+4. 以下の check を required に追加:
+   - "Gate A — Environment Readiness"
+   - "Gate B — Planning Completeness"
+   - "Gate C — SSOT Completeness"
+5. Save changes
+```
+
+> **Note**: `framework gate reset` は廃止されました (#62)。
+> Gate の再実行は新しいコミットの push、または GitHub Actions の workflow re-run で行います。
 
 ---
 

--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -205,27 +205,20 @@ export function registerGateCommand(program: Command): void {
       }
     });
 
-  // framework gate reset (deprecated — gates are now managed by GitHub Actions check runs)
+  // framework gate reset — removed (#62)
   gate
     .command("reset")
-    .description("Reset all gates to pending (deprecated: use GitHub Actions re-run instead)")
+    .description("(Removed) Gates are managed by GitHub Actions check runs")
     .action(async () => {
-      const projectDir = process.cwd();
-
-      console.warn(
-        "[deprecated] 'framework gate reset' resets local gates.json only. " +
-        "Gates are now managed by GitHub Actions check runs. " +
-        "To re-run gates, push a new commit or re-run workflows in GitHub. See #62.",
-      );
-
-      let state = loadGateState(projectDir);
-      if (!state) {
-        state = createGateState();
-      }
-      resetGateState(state);
-      saveGateState(projectDir, state);
-
-      logger.success("All gates reset to pending (local only).");
+      logger.error("'framework gate reset' has been removed.");
+      logger.info("");
+      logger.info("Gates are now managed by GitHub Actions check runs.");
+      logger.info("To re-run gate checks:");
+      logger.info("  1. Push a new commit, or");
+      logger.info("  2. Re-run workflows in GitHub Actions");
+      logger.info("");
+      logger.info("See: .github/workflows/gate-a.yml, gate-b.yml, gate-c.yml");
+      process.exit(1);
       logger.info(
         "Run 'framework gate check' to re-evaluate.",
       );

--- a/src/cli/commands/init-action.ts
+++ b/src/cli/commands/init-action.ts
@@ -205,10 +205,9 @@ export async function initProject(options: InitOptions): Promise<InitResult> {
   fs.writeFileSync(statePath, generateProjectState(config), "utf-8");
   createdFiles.push(".framework/project.json");
 
-  // Initialize gate state (all pending)
-  const gateState = createGateState();
-  saveGateState(projectPath, gateState);
-  createdFiles.push(".framework/gates.json");
+  // Gate state: managed by GitHub Actions check runs (#62)
+  // Local gates.json is created on-demand by `framework gate check` (local cache for hooks).
+  // No longer auto-created at init time.
 
   // Initialize testing config (ADR-010)
   const testRec = recommendTestTools({ profileType: profileType });

--- a/src/cli/commands/retrofit.ts
+++ b/src/cli/commands/retrofit.ts
@@ -103,15 +103,14 @@ export function registerRetrofitCommand(program: Command): void {
             process.exit(1);
           }
 
-          // Initialize gate state if not exists
+          // Gate state: managed by GitHub Actions check runs (#62)
+          // Local gates.json created on-demand by `framework gate check`.
           if (!options.dryRun && !loadGateState(projectDir)) {
-            const gateState = createGateState();
-            saveGateState(projectDir, gateState);
-            logger.success(
-              "Initialized Pre-Code Gate state (.framework/gates.json)",
+            logger.info(
+              "  Gate state: managed by GitHub Actions (gate-a/b/c.yml).",
             );
             logger.info(
-              "  Run 'framework gate check' to evaluate gate status.",
+              "  Run 'framework gate check' for local cache if needed.",
             );
           }
 


### PR DESCRIPTION
## Summary
- #62 の sub-PR 4/4 (最終): gate reset 廃止 + gates.json 自動生成停止 + branch protection ドキュメント
- Closes #62

## Changes (4 files, +43 -31)

### 廃止
- `framework gate reset` → exit 1 + GitHub Actions re-run への案内

### 停止
- `framework init` → gates.json 自動生成を停止 (on-demand by `gate check`)
- `framework retrofit` → 同上

### ドキュメント追加
- `06_CODE_QUALITY.md` → Branch Protection 設定手順 (adopter 向け)
  - Gate A/B/C workflow names を required status checks に追加する手順
  - Gate reset 廃止の注記

## #62 全 sub-PR 完了サマリー

| Sub-PR | PR | Scope | Status |
|---|---|---|---|
| 1/4 | #83 | Gate A/B/C workflows 新設 | ✅ merged |
| 2/4 | #84 | Check run 参照 API | ✅ merged |
| 3/4 | #85 | Consumer → check runs 切替 | ✅ merged |
| 4/4 | #86 | Cleanup (this PR) | 🔵 review |

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 1544 existing tests pass (5 pre-existing failures, unrelated)
- [x] No regressions

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)