### PR TITLE
feat(enforcement): framework mode check — base API + hook script (#63 sub-PR 1/3)

### DIFF
--- a/.claude/hooks/framework-mode-check.sh
+++ b/.claude/hooks/framework-mode-check.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Framework Mode Check — sourced by all hooks before execution.
+#
+# Checks if the repo has `framework-managed` topic via GitHub API.
+# If topic is absent, hooks are passthrough no-ops (exit 0 immediately).
+# If topic is present, hooks enforce gates.
+#
+# Part of #63 (framework mode state machine).
+# Spec: 09_ENFORCEMENT §1.
+#
+# Usage (in hook scripts):
+#   source "$CLAUDE_PROJECT_DIR/.claude/hooks/framework-mode-check.sh"
+#   # If we reach here, framework is active — proceed with checks
+#
+# Environment:
+#   FRAMEWORK_BYPASS — CEO secret token. If set, skip mode check (bypass).
+#   CLAUDE_PROJECT_DIR — project root directory.
+
+project_dir="${CLAUDE_PROJECT_DIR:-.}"
+
+# Bypass: if FRAMEWORK_BYPASS token is set, skip mode check entirely
+if [ -n "${FRAMEWORK_BYPASS:-}" ]; then
+  # Bypass is allowed but logged (09_ENFORCEMENT §2 handles audit logging)
+  return 0 2>/dev/null || exit 0
+fi
+
+# Check framework-managed topic via gh API (5s timeout)
+# If gh is unavailable or errors, default to active (fail-safe)
+framework_active=$(node -e "
+  const { execSync } = require('child_process');
+  try {
+    const out = execSync('gh api repos/{owner}/{repo} --jq \".topics\"', {
+      timeout: 5000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    const topics = JSON.parse(out);
+    console.log(topics.includes('framework-managed') ? 'active' : 'inactive');
+  } catch {
+    // gh unavailable or error — default to active (fail-safe)
+    console.log('active');
+  }
+" 2>/dev/null)
+
+if [ "$framework_active" = "inactive" ]; then
+  # Framework not active — hooks are passthrough no-ops
+  return 0 2>/dev/null || exit 0
+fi
+
+# Framework is active — continue with hook enforcement

--- a/.claude/hooks/framework-mode-check.sh
+++ b/.claude/hooks/framework-mode-check.sh
@@ -21,7 +21,7 @@ project_dir="${CLAUDE_PROJECT_DIR:-.}"
 # Bypass: if FRAMEWORK_BYPASS token is set, skip mode check entirely
 if [ -n "${FRAMEWORK_BYPASS:-}" ]; then
   # Bypass is allowed but logged (09_ENFORCEMENT §2 handles audit logging)
-  return 0 2>/dev/null || exit 0
+  exit 0
 fi
 
 # Check framework-managed topic via gh API (5s timeout)
@@ -44,7 +44,7 @@ framework_active=$(node -e "
 
 if [ "$framework_active" = "inactive" ]; then
   # Framework not active — hooks are passthrough no-ops
-  return 0 2>/dev/null || exit 0
+  exit 0
 fi
 
 # Framework is active — continue with hook enforcement

--- a/src/cli/lib/framework-mode.test.ts
+++ b/src/cli/lib/framework-mode.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import {
   getFrameworkMode,
   activateFrameworkMode,
@@ -51,20 +55,23 @@ describe("activateFrameworkMode", () => {
   });
 
   it("adds topic when not present", async () => {
+    let callIndex = 0;
     restoreGh = setGhExecutor(async (args: string[]) => {
       ghCalls.push(args);
-      if (args.includes("--method")) return "";
-      return JSON.stringify(["existing-topic"]);
+      callIndex++;
+      // First call: getFrameworkMode → inactive
+      if (args.includes("--jq")) return JSON.stringify(["existing-topic"]);
+      // Second call: gh repo edit --add-topic
+      return "";
     });
 
     const result = await activateFrameworkMode();
     expect(result.ok).toBe(true);
     expect(result.alreadyActive).toBe(false);
 
-    const putCall = ghCalls.find((c) => c.includes("PUT"));
-    expect(putCall).toBeDefined();
-    const namesArg = putCall!.find((a) => a.startsWith("names="));
-    expect(namesArg).toContain(FRAMEWORK_TOPIC);
+    const addCall = ghCalls.find((c) => c.includes("--add-topic"));
+    expect(addCall).toBeDefined();
+    expect(addCall).toContain(FRAMEWORK_TOPIC);
   });
 
   it("returns alreadyActive when topic exists", async () => {
@@ -114,18 +121,18 @@ describe("deactivateFrameworkMode", () => {
   it("removes topic with valid token", async () => {
     restoreGh = setGhExecutor(async (args: string[]) => {
       ghCalls.push(args);
-      if (args.includes("--method")) return "";
-      return JSON.stringify(["framework-managed", "keep-this"]);
+      // getFrameworkMode → active
+      if (args.includes("--jq")) return JSON.stringify(["framework-managed", "keep-this"]);
+      // gh repo edit --remove-topic
+      return "";
     });
 
     const result = await deactivateFrameworkMode("any-token");
     expect(result.ok).toBe(true);
 
-    const putCall = ghCalls.find((c) => c.includes("PUT"));
-    expect(putCall).toBeDefined();
-    const namesArg = putCall!.find((a) => a.startsWith("names="));
-    expect(namesArg).not.toContain(FRAMEWORK_TOPIC);
-    expect(namesArg).toContain("keep-this");
+    const removeCall = ghCalls.find((c) => c.includes("--remove-topic"));
+    expect(removeCall).toBeDefined();
+    expect(removeCall).toContain(FRAMEWORK_TOPIC);
   });
 
   it("succeeds when topic already absent", async () => {
@@ -133,5 +140,73 @@ describe("deactivateFrameworkMode", () => {
 
     const result = await deactivateFrameworkMode("token");
     expect(result.ok).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Shell hook tests (framework-mode-check.sh)
+// ─────────────────────────────────────────────
+
+describe("framework-mode-check.sh", () => {
+  let tmpDir: string;
+  const scriptPath = path.resolve("templates/hooks/framework-mode-check.sh");
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mode-check-"));
+    // Create mock gh that returns topics
+    fs.mkdirSync(path.join(tmpDir, "bin"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeMockGh(topics: string[]): void {
+    const script = `#!/bin/bash\necho '${JSON.stringify(topics)}'`;
+    fs.writeFileSync(path.join(tmpDir, "bin/gh"), script, { mode: 0o755 });
+  }
+
+  function runModeCheck(env: Record<string, string> = {}): number {
+    // Wrap in a script that sources the mode-check, then runs a marker command
+    const wrapper = `#!/bin/bash\nsource "${scriptPath}"\necho "HOOK_ACTIVE"`;
+    const wrapperPath = path.join(tmpDir, "test-hook.sh");
+    fs.writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+
+    try {
+      const result = execSync(`bash "${wrapperPath}"`, {
+        env: {
+          ...process.env,
+          PATH: `${tmpDir}/bin:${process.env.PATH}`,
+          CLAUDE_PROJECT_DIR: tmpDir,
+          ...env,
+        },
+        encoding: "utf8",
+        timeout: 10000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      // If HOOK_ACTIVE is in output, the hook continued (framework active)
+      return result.includes("HOOK_ACTIVE") ? 1 : 0;
+    } catch {
+      // exit 0 from mode-check → shell exits before HOOK_ACTIVE
+      return 0;
+    }
+  }
+
+  it("passes through when topic is absent (inactive)", () => {
+    writeMockGh(["other-topic"]);
+    const result = runModeCheck();
+    expect(result).toBe(0); // exited early, hook is no-op
+  });
+
+  it("continues enforcement when topic is present (active)", () => {
+    writeMockGh(["framework-managed"]);
+    const result = runModeCheck();
+    expect(result).toBe(1); // reached HOOK_ACTIVE
+  });
+
+  it("passes through with FRAMEWORK_BYPASS set", () => {
+    writeMockGh(["framework-managed"]);
+    const result = runModeCheck({ FRAMEWORK_BYPASS: "some-token" });
+    expect(result).toBe(0); // bypassed
   });
 });

--- a/src/cli/lib/framework-mode.test.ts
+++ b/src/cli/lib/framework-mode.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getFrameworkMode,
+  activateFrameworkMode,
+  deactivateFrameworkMode,
+  FRAMEWORK_TOPIC,
+} from "./framework-mode.js";
+import { setGhExecutor } from "./github-engine.js";
+
+describe("getFrameworkMode", () => {
+  let restoreGh: () => void;
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+  });
+
+  it("returns active when topic is present", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify(["framework-managed", "other-topic"]),
+    );
+    expect(await getFrameworkMode()).toBe("active");
+  });
+
+  it("returns inactive when topic is absent", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify(["other-topic"]),
+    );
+    expect(await getFrameworkMode()).toBe("inactive");
+  });
+
+  it("returns inactive for empty topics", async () => {
+    restoreGh = setGhExecutor(async () => "[]");
+    expect(await getFrameworkMode()).toBe("inactive");
+  });
+
+  it("returns unknown on gh error", async () => {
+    restoreGh = setGhExecutor(async () => {
+      throw new Error("gh: not authenticated");
+    });
+    expect(await getFrameworkMode()).toBe("unknown");
+  });
+});
+
+describe("activateFrameworkMode", () => {
+  let restoreGh: () => void;
+  let ghCalls: string[][] = [];
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+    ghCalls = [];
+  });
+
+  it("adds topic when not present", async () => {
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      ghCalls.push(args);
+      if (args.includes("--method")) return "";
+      return JSON.stringify(["existing-topic"]);
+    });
+
+    const result = await activateFrameworkMode();
+    expect(result.ok).toBe(true);
+    expect(result.alreadyActive).toBe(false);
+
+    const putCall = ghCalls.find((c) => c.includes("PUT"));
+    expect(putCall).toBeDefined();
+    const namesArg = putCall!.find((a) => a.startsWith("names="));
+    expect(namesArg).toContain(FRAMEWORK_TOPIC);
+  });
+
+  it("returns alreadyActive when topic exists", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify(["framework-managed"]),
+    );
+
+    const result = await activateFrameworkMode();
+    expect(result.ok).toBe(true);
+    expect(result.alreadyActive).toBe(true);
+  });
+
+  it("returns error on gh failure", async () => {
+    restoreGh = setGhExecutor(async () => {
+      throw new Error("gh: permission denied");
+    });
+
+    const result = await activateFrameworkMode();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("permission denied");
+  });
+});
+
+describe("deactivateFrameworkMode", () => {
+  let restoreGh: () => void;
+  let ghCalls: string[][] = [];
+
+  afterEach(() => {
+    if (restoreGh) restoreGh();
+    ghCalls = [];
+    delete process.env.FRAMEWORK_BYPASS_EXPECTED;
+  });
+
+  it("rejects without token", async () => {
+    const result = await deactivateFrameworkMode("");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("token required");
+  });
+
+  it("rejects with wrong token when expected is set", async () => {
+    process.env.FRAMEWORK_BYPASS_EXPECTED = "correct-token";
+    const result = await deactivateFrameworkMode("wrong-token");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Invalid");
+  });
+
+  it("removes topic with valid token", async () => {
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      ghCalls.push(args);
+      if (args.includes("--method")) return "";
+      return JSON.stringify(["framework-managed", "keep-this"]);
+    });
+
+    const result = await deactivateFrameworkMode("any-token");
+    expect(result.ok).toBe(true);
+
+    const putCall = ghCalls.find((c) => c.includes("PUT"));
+    expect(putCall).toBeDefined();
+    const namesArg = putCall!.find((a) => a.startsWith("names="));
+    expect(namesArg).not.toContain(FRAMEWORK_TOPIC);
+    expect(namesArg).toContain("keep-this");
+  });
+
+  it("succeeds when topic already absent", async () => {
+    restoreGh = setGhExecutor(async () => JSON.stringify(["other"]));
+
+    const result = await deactivateFrameworkMode("token");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/cli/lib/framework-mode.ts
+++ b/src/cli/lib/framework-mode.ts
@@ -1,0 +1,125 @@
+/**
+ * Framework mode state machine — repo topic management.
+ *
+ * Part of #63 (framework mode state machine).
+ * Spec: 09_ENFORCEMENT §1.
+ *
+ * States:
+ *   active   — repo has `framework-managed` topic. Hooks enforce gates.
+ *   inactive — topic absent. Hooks are passthrough no-ops.
+ *
+ * Transitions:
+ *   init/retrofit → active (add topic)
+ *   exit (CEO token) → inactive (remove topic)
+ */
+import { execGh } from "./github-engine.js";
+
+const FRAMEWORK_TOPIC = "framework-managed";
+
+// ─────────────────────────────────────────────
+// Read state
+// ─────────────────────────────────────────────
+
+export type FrameworkMode = "active" | "inactive" | "unknown";
+
+export async function getFrameworkMode(): Promise<FrameworkMode> {
+  try {
+    const output = await execGh([
+      "api",
+      "repos/{owner}/{repo}",
+      "--jq",
+      ".topics",
+    ]);
+    const topics = JSON.parse(output) as string[];
+    return topics.includes(FRAMEWORK_TOPIC) ? "active" : "inactive";
+  } catch {
+    return "unknown";
+  }
+}
+
+// ─────────────────────────────────────────────
+// Write state
+// ─────────────────────────────────────────────
+
+async function getRepoTopics(): Promise<string[]> {
+  const output = await execGh([
+    "api",
+    "repos/{owner}/{repo}",
+    "--jq",
+    ".topics",
+  ]);
+  return JSON.parse(output) as string[];
+}
+
+export async function activateFrameworkMode(): Promise<{
+  ok: boolean;
+  alreadyActive: boolean;
+  error?: string;
+}> {
+  try {
+    const topics = await getRepoTopics();
+    if (topics.includes(FRAMEWORK_TOPIC)) {
+      return { ok: true, alreadyActive: true };
+    }
+
+    const newTopics = [...topics, FRAMEWORK_TOPIC];
+    await execGh([
+      "api",
+      "repos/{owner}/{repo}",
+      "--method",
+      "PUT",
+      "--field",
+      `names=${JSON.stringify(newTopics)}`,
+      "--silent",
+    ]);
+    return { ok: true, alreadyActive: false };
+  } catch (e) {
+    return {
+      ok: false,
+      alreadyActive: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+export async function deactivateFrameworkMode(
+  bypassToken: string,
+): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  if (!bypassToken) {
+    return { ok: false, error: "FRAMEWORK_BYPASS token required" };
+  }
+
+  const expectedToken = process.env.FRAMEWORK_BYPASS_EXPECTED;
+  if (expectedToken && bypassToken !== expectedToken) {
+    return { ok: false, error: "Invalid FRAMEWORK_BYPASS token" };
+  }
+
+  try {
+    const topics = await getRepoTopics();
+    if (!topics.includes(FRAMEWORK_TOPIC)) {
+      return { ok: true }; // Already inactive
+    }
+
+    const newTopics = topics.filter((t) => t !== FRAMEWORK_TOPIC);
+    await execGh([
+      "api",
+      "repos/{owner}/{repo}",
+      "--method",
+      "PUT",
+      "--field",
+      `names=${JSON.stringify(newTopics)}`,
+      "--silent",
+    ]);
+    return { ok: true };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+export { FRAMEWORK_TOPIC };

--- a/src/cli/lib/framework-mode.ts
+++ b/src/cli/lib/framework-mode.ts
@@ -41,36 +41,22 @@ export async function getFrameworkMode(): Promise<FrameworkMode> {
 // Write state
 // ─────────────────────────────────────────────
 
-async function getRepoTopics(): Promise<string[]> {
-  const output = await execGh([
-    "api",
-    "repos/{owner}/{repo}",
-    "--jq",
-    ".topics",
-  ]);
-  return JSON.parse(output) as string[];
-}
-
 export async function activateFrameworkMode(): Promise<{
   ok: boolean;
   alreadyActive: boolean;
   error?: string;
 }> {
   try {
-    const topics = await getRepoTopics();
-    if (topics.includes(FRAMEWORK_TOPIC)) {
+    const mode = await getFrameworkMode();
+    if (mode === "active") {
       return { ok: true, alreadyActive: true };
     }
 
-    const newTopics = [...topics, FRAMEWORK_TOPIC];
     await execGh([
-      "api",
-      "repos/{owner}/{repo}",
-      "--method",
-      "PUT",
-      "--field",
-      `names=${JSON.stringify(newTopics)}`,
-      "--silent",
+      "repo",
+      "edit",
+      "--add-topic",
+      FRAMEWORK_TOPIC,
     ]);
     return { ok: true, alreadyActive: false };
   } catch (e) {
@@ -98,20 +84,16 @@ export async function deactivateFrameworkMode(
   }
 
   try {
-    const topics = await getRepoTopics();
-    if (!topics.includes(FRAMEWORK_TOPIC)) {
+    const mode = await getFrameworkMode();
+    if (mode === "inactive") {
       return { ok: true }; // Already inactive
     }
 
-    const newTopics = topics.filter((t) => t !== FRAMEWORK_TOPIC);
     await execGh([
-      "api",
-      "repos/{owner}/{repo}",
-      "--method",
-      "PUT",
-      "--field",
-      `names=${JSON.stringify(newTopics)}`,
-      "--silent",
+      "repo",
+      "edit",
+      "--remove-topic",
+      FRAMEWORK_TOPIC,
     ]);
     return { ok: true };
   } catch (e) {

--- a/templates/hooks/framework-mode-check.sh
+++ b/templates/hooks/framework-mode-check.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Framework Mode Check — sourced by all hooks before execution.
+#
+# Checks if the repo has `framework-managed` topic via GitHub API.
+# If topic is absent, hooks are passthrough no-ops (exit 0 immediately).
+# If topic is present, hooks enforce gates.
+#
+# Part of #63 (framework mode state machine).
+# Spec: 09_ENFORCEMENT §1.
+#
+# Usage (in hook scripts):
+#   source "$CLAUDE_PROJECT_DIR/.claude/hooks/framework-mode-check.sh"
+#   # If we reach here, framework is active — proceed with checks
+#
+# Environment:
+#   FRAMEWORK_BYPASS — CEO secret token. If set, skip mode check (bypass).
+#   CLAUDE_PROJECT_DIR — project root directory.
+
+project_dir="${CLAUDE_PROJECT_DIR:-.}"
+
+# Bypass: if FRAMEWORK_BYPASS token is set, skip mode check entirely
+if [ -n "${FRAMEWORK_BYPASS:-}" ]; then
+  # Bypass is allowed but logged (09_ENFORCEMENT §2 handles audit logging)
+  return 0 2>/dev/null || exit 0
+fi
+
+# Check framework-managed topic via gh API (5s timeout)
+# If gh is unavailable or errors, default to active (fail-safe)
+framework_active=$(node -e "
+  const { execSync } = require('child_process');
+  try {
+    const out = execSync('gh api repos/{owner}/{repo} --jq \".topics\"', {
+      timeout: 5000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    const topics = JSON.parse(out);
+    console.log(topics.includes('framework-managed') ? 'active' : 'inactive');
+  } catch {
+    // gh unavailable or error — default to active (fail-safe)
+    console.log('active');
+  }
+" 2>/dev/null)
+
+if [ "$framework_active" = "inactive" ]; then
+  # Framework not active — hooks are passthrough no-ops
+  return 0 2>/dev/null || exit 0
+fi
+
+# Framework is active — continue with hook enforcement

--- a/templates/hooks/framework-mode-check.sh
+++ b/templates/hooks/framework-mode-check.sh
@@ -21,7 +21,7 @@ project_dir="${CLAUDE_PROJECT_DIR:-.}"
 # Bypass: if FRAMEWORK_BYPASS token is set, skip mode check entirely
 if [ -n "${FRAMEWORK_BYPASS:-}" ]; then
   # Bypass is allowed but logged (09_ENFORCEMENT §2 handles audit logging)
-  return 0 2>/dev/null || exit 0
+  exit 0
 fi
 
 # Check framework-managed topic via gh API (5s timeout)
@@ -44,7 +44,7 @@ framework_active=$(node -e "
 
 if [ "$framework_active" = "inactive" ]; then
   # Framework not active — hooks are passthrough no-ops
-  return 0 2>/dev/null || exit 0
+  exit 0
 fi
 
 # Framework is active — continue with hook enforcement


### PR DESCRIPTION
## Summary
- #63 の sub-PR 1/3: framework mode state machine の基盤 API + hook script
- 既存コード変更なし — 新規ファイル追加のみ

## Scope (本 PR)
- `getFrameworkMode()` / `activateFrameworkMode()` / `deactivateFrameworkMode()` API
- `framework-mode-check.sh` hook source 用共通 script
- 14 tests (11 TS + 3 shell)

## NOT in scope (sub-PR 2/3 で実装)
- `framework exit` CLI コマンド (§1 Exit) → sub-PR 3
- audit log 連携 (§1/§2 — activate/deactivate/bypass 時のログ) → sub-PR 2/3
- init/retrofit コマンドへの `activateFrameworkMode()` 配線 → sub-PR 2
- 全 hook への `framework-mode-check.sh` source 組込 → sub-PR 2
- FRAMEWORK_BYPASS audit logging (#65 連携) → sub-PR 2/3

## Changes (4 new files, +362 lines)

### Shell script
- `templates/hooks/framework-mode-check.sh` + `.claude/hooks/framework-mode-check.sh`
  - `framework-managed` topic → enforce、topic なし → `exit 0` (passthrough)
  - `FRAMEWORK_BYPASS` env var → `exit 0` (bypass)
  - gh unavailable → fail-safe (active)

### TypeScript API
- `src/cli/lib/framework-mode.ts`
  - `getFrameworkMode()`: "active" | "inactive" | "unknown"
  - `activateFrameworkMode()`: `gh repo edit --add-topic` (idempotent)
  - `deactivateFrameworkMode(token)`: token 検証 + `gh repo edit --remove-topic`

### Tests
- `src/cli/lib/framework-mode.test.ts` — 14 tests (11 TS + 3 shell)

Ref: #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)