### PR TITLE
feat(enforcement): wire mode activation + hook integration (#63 sub-PR 2/3)

### DIFF
--- a/.claude/hooks/pre-code-gate.sh
+++ b/.claude/hooks/pre-code-gate.sh
@@ -10,6 +10,12 @@ tool=$(echo "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c);proces
 
 project_dir="${CLAUDE_PROJECT_DIR:-.}"
 
+# Framework mode check: if repo lacks framework-managed topic, exit 0 (passthrough) (#63)
+mode_check="$project_dir/.claude/hooks/framework-mode-check.sh"
+if [ -f "$mode_check" ]; then
+  source "$mode_check"
+fi
+
 # Extract file path based on tool type
 file_path=""
 if [ "$tool" = "Edit" ] || [ "$tool" = "Write" ]; then

--- a/src/cli/commands/init-action.ts
+++ b/src/cli/commands/init-action.ts
@@ -29,6 +29,7 @@ import {
   saveGateState,
 } from "../lib/gate-model.js";
 import { installAllHooks } from "../lib/hooks-installer.js";
+import { activateFrameworkMode } from "../lib/framework-mode.js";
 import {
   recommendTestTools,
   recommendationToConfig,
@@ -226,6 +227,19 @@ export async function initProject(options: InitOptions): Promise<InitResult> {
   }
   if (hooksResult.gitHookInstalled) {
     logger.success("Git pre-commit hook installed");
+  }
+
+  // Step 10a: Activate framework mode (repo topic) (#63)
+  const modeResult = await activateFrameworkMode();
+  if (modeResult.ok) {
+    if (modeResult.alreadyActive) {
+      logger.info("  Framework mode: already active (topic exists)");
+    } else {
+      logger.success("Framework mode activated (framework-managed topic added)");
+    }
+  } else {
+    logger.warn(`  Framework mode activation failed: ${modeResult.error ?? "unknown"}`);
+    logger.info("  Hooks will still enforce locally. Run 'gh repo edit --add-topic framework-managed' manually.");
   }
 
   // Step 10b: Install gate scripts (scripts/gates/)

--- a/src/cli/commands/retrofit.ts
+++ b/src/cli/commands/retrofit.ts
@@ -27,6 +27,7 @@ import {
   saveGateState,
 } from "../lib/gate-model.js";
 import { installAllHooks } from "../lib/hooks-installer.js";
+import { activateFrameworkMode } from "../lib/framework-mode.js";
 import { installGitHubTemplates } from "../lib/github-templates.js";
 import { loadProfileType, inferProfileType } from "../lib/profile-model.js";
 import { logger } from "../lib/logger.js";
@@ -162,6 +163,20 @@ export function registerRetrofitCommand(program: Command): void {
             }
             if (hooksResult.gitHookInstalled) {
               logger.success("Git pre-commit hook installed");
+            }
+          }
+
+          // Activate framework mode (repo topic) (#63)
+          if (!options.dryRun) {
+            const modeResult = await activateFrameworkMode();
+            if (modeResult.ok) {
+              if (modeResult.alreadyActive) {
+                logger.info("  Framework mode: already active");
+              } else {
+                logger.success("Framework mode activated (framework-managed topic)");
+              }
+            } else {
+              logger.warn(`  Framework mode activation failed: ${modeResult.error ?? "unknown"}`);
             }
           }
 

--- a/src/cli/lib/hooks-installer.ts
+++ b/src/cli/lib/hooks-installer.ts
@@ -34,6 +34,12 @@ tool=$(echo "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c);proces
 
 project_dir="\${CLAUDE_PROJECT_DIR:-.}"
 
+# Framework mode check: if repo lacks framework-managed topic, exit 0 (passthrough) (#63)
+mode_check="$project_dir/.claude/hooks/framework-mode-check.sh"
+if [ -f "$mode_check" ]; then
+  source "$mode_check"
+fi
+
 # Extract file path based on tool type
 file_path=""
 if [ "$tool" = "Edit" ] || [ "$tool" = "Write" ]; then
@@ -268,6 +274,15 @@ export function installClaudeCodeHook(projectDir: string): {
   const skillTrackerPath = path.join(hooksDir, "skill-tracker.sh");
   fs.writeFileSync(skillTrackerPath, SKILL_TRACKER_SCRIPT, { mode: 0o755 });
   files.push(".claude/hooks/skill-tracker.sh");
+
+  // 2b2. Copy framework-mode-check.sh from templates (#63)
+  const modeCheckSrcPath = path.resolve(__dirname, "../../../templates/hooks/framework-mode-check.sh");
+  if (fs.existsSync(modeCheckSrcPath)) {
+    const modeCheckDestPath = path.join(hooksDir, "framework-mode-check.sh");
+    fs.copyFileSync(modeCheckSrcPath, modeCheckDestPath);
+    fs.chmodSync(modeCheckDestPath, 0o755);
+    files.push(".claude/hooks/framework-mode-check.sh");
+  }
 
   // 2c. Copy framework-runner.sh from templates
   const runnerSrcPath = path.resolve(__dirname, "../../../templates/hooks/framework-runner.sh");

--- a/src/cli/lib/pre-code-gate-hook.test.ts
+++ b/src/cli/lib/pre-code-gate-hook.test.ts
@@ -57,11 +57,21 @@ function writeGatesPassed(): void {
   );
 }
 
-/** Helper: create a mock gh script that returns specified Issues */
-function setupMockGh(issues: { number: number; title: string }[]): void {
+/** Helper: create a mock gh script that handles both topic check and issue list */
+function setupMockGh(issues: { number: number; title: string }[], topicActive = true): void {
   const binDir = path.join(tmpDir, "bin");
   fs.mkdirSync(binDir, { recursive: true });
-  const script = `#!/bin/bash\necho '${JSON.stringify(issues)}'`;
+  const topics = topicActive ? '["framework-managed"]' : '["other"]';
+  const issueJson = JSON.stringify(issues);
+  // Mock gh: if called with "api", return topics; if called with "issue", return issues
+  const script = `#!/bin/bash
+if echo "$@" | grep -q "api"; then
+  echo '${topics}'
+elif echo "$@" | grep -q "issue"; then
+  echo '${issueJson}'
+else
+  echo '[]'
+fi`;
   const ghPath = path.join(binDir, "gh");
   fs.writeFileSync(ghPath, script, { mode: 0o755 });
 }
@@ -98,6 +108,9 @@ beforeEach(() => {
   // Install hook via the installer (canonical source)
   installClaudeCodeHook(tmpDir);
   hookPath = path.join(tmpDir, ".claude/hooks/pre-code-gate.sh");
+
+  // Default mock gh: framework-managed topic active, no active issues
+  setupMockGh([], true);
 
   // Fix the tool input path to use actual tmpDir
   editSrcInput.tool_input.file_path = path.join(tmpDir, "src/auth/login.ts");

--- a/templates/hooks/pre-code-gate.sh
+++ b/templates/hooks/pre-code-gate.sh
@@ -10,6 +10,12 @@ tool=$(echo "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c);proces
 
 project_dir="\${CLAUDE_PROJECT_DIR:-.}"
 
+# Framework mode check: if repo lacks framework-managed topic, exit 0 (passthrough) (#63)
+mode_check="$project_dir/.claude/hooks/framework-mode-check.sh"
+if [ -f "$mode_check" ]; then
+  source "$mode_check"
+fi
+
 # Extract file path based on tool type
 file_path=""
 if [ "$tool" = "Edit" ] || [ "$tool" = "Write" ]; then


### PR DESCRIPTION
## Summary
- #63 の sub-PR 2/3: init/retrofit に mode activation + 全 hook に mode check 組込
- `framework init` / `retrofit` 実行時に `framework-managed` topic を自動付与
- pre-code-gate.sh が topic をチェックし、topic なし → passthrough

## Changes (6 files, +72 -3)

### Commands
- `init-action.ts`: `activateFrameworkMode()` 呼出追加 (hooks install 後)
- `retrofit.ts`: 同上

### Hooks
- `hooks-installer.ts`: `framework-mode-check.sh` のコピー追加 + pre-code-gate template に source 追加
- `.claude/hooks/pre-code-gate.sh`: mode check source 追加 (active hook)
- `templates/hooks/pre-code-gate.sh`: 同上 (template)

### Tests
- `pre-code-gate-hook.test.ts`: mock gh を topic API + issue list 両対応に更新

## Scope
**本 PR:** init/retrofit activation + hook mode check 組込
**sub-PR 3:** `framework exit` CLI コマンド + audit log 連携

## Test plan
- [x] 11 hook tests pass (mock gh updated for topic + issue dual response)
- [x] tsc --noEmit: 0 errors
- [x] Topic absent → hook passthrough (exit 0)
- [x] Topic present → hook enforces gates

Ref: #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)