### PR TITLE
feat(enforcement): read-receipts workflow + config generator (#64 sub-PR 2/4)

### DIFF
--- a/.github/workflows/read-receipts.yml
+++ b/.github/workflows/read-receipts.yml
@@ -1,0 +1,117 @@
+name: "Read Receipts"
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  read-receipts:
+    name: Read-Receipt Verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            npm install -g pnpm && pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --frozen-lockfile
+          else
+            npm ci
+          fi
+
+      - name: Check required-reading.json exists
+        id: config
+        run: |
+          if [ -f .framework/required-reading.json ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No .framework/required-reading.json found. Read-receipt verification skipped."
+          fi
+
+      - name: Server-side hash verification (Layer 1)
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const crypto = require('crypto');
+
+            const config = JSON.parse(fs.readFileSync('.framework/required-reading.json', 'utf-8'));
+            let failures = 0;
+
+            for (const reading of config.readings) {
+              if (!fs.existsSync(reading.specFile)) {
+                console.log('::error::Spec file not found: ' + reading.specFile);
+                failures++;
+                continue;
+              }
+
+              const content = fs.readFileSync(reading.specFile, 'utf-8');
+              const actualHash = crypto.createHash('sha256').update(content).digest('hex');
+
+              if (actualHash !== reading.expectedHash) {
+                console.log('::error::Hash mismatch for ' + reading.specFile +
+                  ': config=' + reading.expectedHash.slice(0, 8) + '...' +
+                  ' actual=' + actualHash.slice(0, 8) + '...' +
+                  '. Regenerate with: framework generate-reading-config');
+                failures++;
+              } else {
+                console.log('✅ Hash match: ' + reading.specFile);
+              }
+            }
+
+            if (failures > 0) {
+              console.log('::error::' + failures + ' spec file(s) have stale hashes. Regenerate required-reading.json.');
+              process.exit(1);
+            }
+            console.log('Layer 1 (File Hash): PASS — all ' + config.readings.length + ' specs verified');
+          "
+
+      - name: Validate grounding questions exist (Layer 2 config check)
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.framework/required-reading.json', 'utf-8'));
+            let failures = 0;
+
+            for (const reading of config.readings) {
+              if (!reading.groundingQuestions || reading.groundingQuestions.length === 0) {
+                console.log('::error::No grounding questions for ' + reading.specFile + '. Regenerate config.');
+                failures++;
+              }
+              if (!reading.challenges || reading.challenges.length === 0) {
+                console.log('::error::No challenges for ' + reading.specFile + '. Regenerate config.');
+                failures++;
+              }
+            }
+
+            if (failures > 0) {
+              process.exit(1);
+            }
+            console.log('Layer 2/3 config check: PASS — all specs have grounding + challenges');
+          "
+
+      - name: Check read-receipt records exist
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          if [ -d .framework/read-receipts ]; then
+            RECEIPT_COUNT=$(find .framework/read-receipts -name "*.json" | wc -l | tr -d ' ')
+            echo "Found $RECEIPT_COUNT read-receipt record(s)"
+            if [ "$RECEIPT_COUNT" -eq 0 ]; then
+              echo "::warning::No read-receipt records found. Verification of Layer 2/3 answers deferred to hook enforcement."
+            fi
+          else
+            echo "::warning::No .framework/read-receipts/ directory. Layer 2/3 answer verification deferred to hook enforcement."
+          fi
+
+      - name: Read-receipts summary
+        if: steps.config.outputs.exists == 'true'
+        run: echo "Read-Receipt Verification — PASSED (server-side hash verified)"

--- a/src/cli/commands/reading-config.ts
+++ b/src/cli/commands/reading-config.ts
@@ -1,0 +1,96 @@
+/**
+ * framework generate-reading-config — Generate required-reading.json from specs.
+ *
+ * Part of #64 (09_ENFORCEMENT §6).
+ *
+ * Scans docs/specs/ for .md files and generates grounding questions
+ * + challenges for read-receipt verification.
+ */
+import type { Command } from "commander";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  generateReadingConfig,
+  saveRequiredReading,
+  loadRequiredReading,
+} from "../lib/read-receipt-engine.js";
+
+export function registerReadingConfigCommand(program: Command): void {
+  program
+    .command("generate-reading-config")
+    .description("Generate .framework/required-reading.json from spec files")
+    .option("--specs <dir>", "Specs directory (default: docs/specs)")
+    .option("--dry-run", "Show what would be generated without writing")
+    .action(
+      async (options: { specs?: string; dryRun?: boolean }) => {
+        const projectDir = process.cwd();
+        const specsDir = options.specs ?? "docs/specs";
+        const fullSpecsDir = path.join(projectDir, specsDir);
+
+        if (!fs.existsSync(fullSpecsDir)) {
+          console.error(`Specs directory not found: ${specsDir}`);
+          process.exit(1);
+        }
+
+        // Find all .md spec files
+        const specFiles: string[] = [];
+        function scanDir(dir: string, prefix: string): void {
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.isDirectory()) {
+              scanDir(path.join(dir, entry.name), `${prefix}${entry.name}/`);
+            } else if (entry.name.endsWith(".md")) {
+              const relPath = `${prefix}${entry.name}`;
+              const fullPath = path.join(dir, entry.name);
+              const stat = fs.statSync(fullPath);
+              // Skip files under 10 lines (likely empty/placeholder)
+              const content = fs.readFileSync(fullPath, "utf-8");
+              if (content.split("\n").length >= 10) {
+                specFiles.push(`${specsDir}/${relPath}`);
+              }
+            }
+          }
+        }
+        scanDir(fullSpecsDir, "");
+
+        if (specFiles.length === 0) {
+          console.log(`No spec files found in ${specsDir}/`);
+          return;
+        }
+
+        console.log(`Found ${specFiles.length} spec files in ${specsDir}/`);
+
+        const config = generateReadingConfig(projectDir, specFiles);
+
+        if (options.dryRun) {
+          console.log("\n--- Dry Run ---\n");
+          for (const r of config.readings) {
+            console.log(`${r.specFile}:`);
+            console.log(`  Hash: ${r.expectedHash.slice(0, 16)}...`);
+            console.log(`  Grounding: ${r.groundingQuestions.length} questions`);
+            console.log(`  Challenges: ${r.challenges.length} questions`);
+          }
+          console.log(`\nTotal: ${config.readings.length} readings`);
+          return;
+        }
+
+        // Check for existing config
+        const existing = loadRequiredReading(projectDir);
+        if (existing) {
+          console.log(`Updating existing config (${existing.readings.length} → ${config.readings.length} readings)`);
+        }
+
+        saveRequiredReading(projectDir, config);
+        console.log(`\nSaved .framework/required-reading.json`);
+        console.log(`  ${config.readings.length} specs`);
+
+        let totalG = 0;
+        let totalC = 0;
+        for (const r of config.readings) {
+          totalG += r.groundingQuestions.length;
+          totalC += r.challenges.length;
+        }
+        console.log(`  ${totalG} grounding questions`);
+        console.log(`  ${totalC} challenges`);
+      },
+    );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import { registerIngestCommand } from "./commands/ingest.js";
 import { registerCheckCommand } from "./commands/check.js";
 import { registerMigrateCommand } from "./commands/migrate.js";
 import { registerExitCommand } from "./commands/exit.js";
+import { registerReadingConfigCommand } from "./commands/reading-config.js";
 import { setWriteThrough, type RunState } from "./lib/run-model.js";
 import { syncTaskStatusToGitHub, resolveIssueNumber } from "./lib/state-writer.js";
 
@@ -101,6 +102,7 @@ registerConfigCommand(program);
 registerImproveCommand(program);
 registerMigrateCommand(program);
 registerExitCommand(program);
+registerReadingConfigCommand(program);
 
 // Connect write-through hook: sync RunState transitions to GitHub Issues (#61)
 setWriteThrough((state: RunState, prev: RunState | null) => {

--- a/templates/ci/read-receipts.yml
+++ b/templates/ci/read-receipts.yml
@@ -1,0 +1,117 @@
+name: "Read Receipts"
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  read-receipts:
+    name: Read-Receipt Verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            npm install -g pnpm && pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            yarn install --frozen-lockfile
+          else
+            npm ci
+          fi
+
+      - name: Check required-reading.json exists
+        id: config
+        run: |
+          if [ -f .framework/required-reading.json ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No .framework/required-reading.json found. Read-receipt verification skipped."
+          fi
+
+      - name: Server-side hash verification (Layer 1)
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const crypto = require('crypto');
+
+            const config = JSON.parse(fs.readFileSync('.framework/required-reading.json', 'utf-8'));
+            let failures = 0;
+
+            for (const reading of config.readings) {
+              if (!fs.existsSync(reading.specFile)) {
+                console.log('::error::Spec file not found: ' + reading.specFile);
+                failures++;
+                continue;
+              }
+
+              const content = fs.readFileSync(reading.specFile, 'utf-8');
+              const actualHash = crypto.createHash('sha256').update(content).digest('hex');
+
+              if (actualHash !== reading.expectedHash) {
+                console.log('::error::Hash mismatch for ' + reading.specFile +
+                  ': config=' + reading.expectedHash.slice(0, 8) + '...' +
+                  ' actual=' + actualHash.slice(0, 8) + '...' +
+                  '. Regenerate with: framework generate-reading-config');
+                failures++;
+              } else {
+                console.log('✅ Hash match: ' + reading.specFile);
+              }
+            }
+
+            if (failures > 0) {
+              console.log('::error::' + failures + ' spec file(s) have stale hashes. Regenerate required-reading.json.');
+              process.exit(1);
+            }
+            console.log('Layer 1 (File Hash): PASS — all ' + config.readings.length + ' specs verified');
+          "
+
+      - name: Validate grounding questions exist (Layer 2 config check)
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.framework/required-reading.json', 'utf-8'));
+            let failures = 0;
+
+            for (const reading of config.readings) {
+              if (!reading.groundingQuestions || reading.groundingQuestions.length === 0) {
+                console.log('::error::No grounding questions for ' + reading.specFile + '. Regenerate config.');
+                failures++;
+              }
+              if (!reading.challenges || reading.challenges.length === 0) {
+                console.log('::error::No challenges for ' + reading.specFile + '. Regenerate config.');
+                failures++;
+              }
+            }
+
+            if (failures > 0) {
+              process.exit(1);
+            }
+            console.log('Layer 2/3 config check: PASS — all specs have grounding + challenges');
+          "
+
+      - name: Check read-receipt records exist
+        if: steps.config.outputs.exists == 'true'
+        run: |
+          if [ -d .framework/read-receipts ]; then
+            RECEIPT_COUNT=$(find .framework/read-receipts -name "*.json" | wc -l | tr -d ' ')
+            echo "Found $RECEIPT_COUNT read-receipt record(s)"
+            if [ "$RECEIPT_COUNT" -eq 0 ]; then
+              echo "::warning::No read-receipt records found. Verification of Layer 2/3 answers deferred to hook enforcement."
+            fi
+          else
+            echo "::warning::No .framework/read-receipts/ directory. Layer 2/3 answer verification deferred to hook enforcement."
+          fi
+
+      - name: Read-receipts summary
+        if: steps.config.outputs.exists == 'true'
+        run: echo "Read-Receipt Verification — PASSED (server-side hash verified)"


### PR DESCRIPTION
## Summary
- #64 の sub-PR 2/4: read-receipts PR check run + `framework generate-reading-config` CLI
- Server-side hash 再計算 (client-submitted hash は信用しない)
- 既存コード変更は index.ts の 2 行のみ

## Changes (4 new files, +332 lines)

### Workflow
- `.github/workflows/read-receipts.yml` — PR check run
  - Layer 1: server-side SHA-256 hash 再計算・突合
  - Config validation: grounding + challenges が空でないこと
  - Read-receipt records 存在チェック
- `templates/ci/read-receipts.yml` — retrofit テンプレート

### CLI
- `src/cli/commands/reading-config.ts` — `framework generate-reading-config`
  - docs/specs/ をスキャンし required-reading.json を自動生成
  - `--dry-run` / `--specs <dir>` オプション

### Modified
- `src/cli/index.ts` — command 登録

## Design
- **Server-side hash**: GitHub Actions が spec file を checkout して hash 計算 → config の expectedHash と突合
- **Hash mismatch → fail**: spec 更新後に config 再生成が必要な場合は明確にエラー表示
- **Layer 2/3 answer verification**: hook enforcement (sub-PR 3) で実行、workflow は config validation のみ

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] 1579 existing tests pass
- [x] YAML syntax valid

Ref: #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)