### PR TITLE
fix(#61-gap): remove notify_then_proceed + goals.json fallback (#93)

### DIFF
--- a/templates/hooks/framework-runner.sh
+++ b/templates/hooks/framework-runner.sh
@@ -58,7 +58,8 @@ try {
   const classified = issues.map(issue => {
     const issueLabels = (issue.labels || []).map(l => (l.name || l).toLowerCase());
 
-    let level = 'notify_then_proceed'; // default
+    // Label-based deterministic routing: autonomous or approval_required only (#61 v1.1.0)
+    let level = 'approval_required'; // default: conservative
     for (const label of issueLabels) {
       if (labelMap[label] === 'autonomous') { level = 'autonomous'; }
       if (labelMap[label] === 'approval_required') { level = 'approval_required'; break; }
@@ -84,7 +85,7 @@ try {
   console.log('============================================');
 
   for (const t of classified.slice(0, 5)) {
-    const icon = t.level === 'autonomous' ? '▶' : t.level === 'notify_then_proceed' ? '⏳' : '🔒';
+    const icon = t.level === 'autonomous' ? '▶' : '🔒';
     console.log('  ' + icon + ' #' + t.number + ' [' + t.level + '] ' + t.title);
   }
   if (classified.length > 5) {

--- a/templates/hooks/post-task.sh
+++ b/templates/hooks/post-task.sh
@@ -19,86 +19,10 @@ if [ -n "$COMPLETED_TASK" ]; then
   echo ""
 fi
 
-# framework-runner.sh があればそれを実行（GitHub Issues SSOT）
+# Delegate to framework-runner.sh (GitHub Issues SSOT, #61)
 if [ -x "$RUNNER" ]; then
   exec bash "$RUNNER"
 fi
 
-# フォールバック: goals.json から次タスクを取得
-GOALS_FILE="$PROJECT_DIR/.framework/goals.json"
-AUTONOMY_FILE="$PROJECT_DIR/.framework/autonomy.json"
-
-if [ ! -f "$GOALS_FILE" ]; then
-  echo "[post-task] goals.json not found, framework-runner.sh not found. No next task."
-  exit 0
-fi
-
-NEXT_TASK=$(node -e "
-  const fs = require('fs');
-  try {
-    const goals = JSON.parse(fs.readFileSync('$GOALS_FILE', 'utf8'));
-    const backlog = goals.backlog || [];
-    for (const status of ['ready', 'pending']) {
-      const task = backlog.find(t => t.status === status);
-      if (task) { console.log(JSON.stringify(task)); process.exit(0); }
-    }
-  } catch {}
-  process.exit(1);
-" 2>/dev/null) || true
-
-if [ -z "$NEXT_TASK" ]; then
-  echo "[post-task] バックログに残タスクなし。"
-  exit 0
-fi
-
-TASK_ID=$(echo "$NEXT_TASK" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).id||'?'))")
-TASK_NAME=$(echo "$NEXT_TASK" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).name||'?'))")
-TASK_PRIORITY=$(echo "$NEXT_TASK" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).priority||'?'))")
-TASK_DESC=$(echo "$NEXT_TASK" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).description||''))")
-
-# autonomy level判定
-LEVEL="notify_then_proceed"
-if [ -f "$AUTONOMY_FILE" ]; then
-  LEVEL=$(node -e "
-    const fs = require('fs');
-    try {
-      const autonomy = JSON.parse(fs.readFileSync('$AUTONOMY_FILE', 'utf8'));
-      const task = $NEXT_TASK;
-      const name = (task.name || '').toLowerCase();
-      const actionMap = {
-        bug:'bug_fix', test:'test', refactor:'refactoring', lint:'lint_fix',
-        crud:'feature_implementation', api:'api_endpoint', ui:'ui_component',
-        db:'db_schema_change', migration:'db_schema_change', security:'security_related'
-      };
-      let action = 'feature_implementation';
-      for (const [kw, act] of Object.entries(actionMap)) {
-        if (name.includes(kw)) { action = act; break; }
-      }
-      for (const [levelName, def] of Object.entries(autonomy.levels || {})) {
-        if ((def.actions || []).includes(action)) { console.log(levelName); process.exit(0); }
-      }
-      console.log('approval_required');
-    } catch { console.log('notify_then_proceed'); }
-  " 2>/dev/null) || LEVEL="notify_then_proceed"
-fi
-
-echo ""
-echo "[提案] 次のタスク"
-echo "  ID: $TASK_ID"
-echo "  名前: $TASK_NAME"
-echo "  優先度: $TASK_PRIORITY"
-echo "  説明: $TASK_DESC"
-echo "  自律レベル: $LEVEL"
-echo ""
-
-case "$LEVEL" in
-  autonomous)
-    echo "  → 自律実行可能。着手して完了後に報告します。"
-    ;;
-  notify_then_proceed)
-    echo "  → 5分以内に[却下]がなければ着手します。"
-    ;;
-  approval_required)
-    echo "  → CTO承認を待ちます。"
-    ;;
-esac
+echo "[post-task] framework-runner.sh not found. No next task."
+exit 0

--- a/templates/project/autonomy.json
+++ b/templates/project/autonomy.json
@@ -5,33 +5,12 @@
     "primary": "github_issues",
     "command": "gh issue list --assignee @me --state open --json number,title,labels,body",
     "cronIntervalMinutes": 10,
-    "fallback": "goals.json"
+    "note": "GitHub Issues is the sole task source (SSOT). goals.json is deprecated (#61)."
   },
   "levels": {
     "autonomous": {
       "description": "自律実行可能。完了後に[報告:完了]のみ送信",
-      "actions": [
-        "bug_fix",
-        "test",
-        "refactoring",
-        "lint_fix",
-        "typo_fix",
-        "documentation_update",
-        "ci_fix"
-      ],
-      "issueLabels": ["bug", "fix", "test", "refactoring", "docs", "lint", "typo", "ci"]
-    },
-    "notify_then_proceed": {
-      "description": "CTOに[提案]を送信し、5分以内に[却下]がなければ着手",
-      "actions": [
-        "feature_implementation",
-        "ui_component",
-        "api_endpoint",
-        "test_coverage_improvement",
-        "dependency_update_minor"
-      ],
-      "issueLabels": ["feature", "enhancement", "ui", "api"],
-      "timeoutMinutes": 5
+      "issueLabels": ["bug", "fix", "test", "refactoring", "docs", "lint", "typo", "ci", "P0"]
     },
     "approval_required": {
       "description": "CTO承認を待ってから着手。[承認依頼]で依頼",


### PR DESCRIPTION
## Summary
- #93: #61 post-merge gap 修正 (autonomy cleanup + label routing)
- notify_then_proceed 削除、goals.json fallback 削除、2-value routing

## Changes (3 files, +8 -104)
- `templates/project/autonomy.json`: notify_then_proceed level 削除 + goals.json fallback → deprecation note
- `templates/hooks/post-task.sh`: goals.json 読取 (L27-104) 全削除、framework-runner.sh delegate のみ
- `templates/hooks/framework-runner.sh`: default → 'approval_required'、icon 簡略化

## Test plan
- [x] tsc clean
- [x] 1579 pass, 0 regressions
- [x] `grep notify_then_proceed templates/` → 0 hits
- [x] `grep goals.json templates/` → deprecation note のみ

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)