### PR TITLE
fix(#62-gap): delete resetGateState + expand test coverage (#94)

### DIFF
--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -23,7 +23,6 @@ import {
   loadGateStatusFromCheckRuns,
   saveGateState,
   createGateState,
-  resetGateState,
   type GateState,
   type GateEntry,
   type SSOTGateEntry,
@@ -219,9 +218,6 @@ export function registerGateCommand(program: Command): void {
       logger.info("");
       logger.info("See: .github/workflows/gate-a.yml, gate-b.yml, gate-c.yml");
       process.exit(1);
-      logger.info(
-        "Run 'framework gate check' to re-evaluate.",
-      );
     });
 
   // framework gate scaffold

--- a/src/cli/lib/audit-log.test.ts
+++ b/src/cli/lib/audit-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { appendAuditLog, logFrameworkExit } from "./audit-log.js";
+import { appendAuditLog, logFrameworkExit, logFrameworkActivation, hashTokenPrefix, validateTokenByHash } from "./audit-log.js";
 import { setGhExecutor } from "./github-engine.js";
 
 describe("appendAuditLog", () => {
@@ -102,5 +102,60 @@ describe("logFrameworkExit", () => {
     const bodyIdx = commentCall.indexOf("--body") + 1;
     expect(commentCall[bodyIdx]).toContain("framework exit");
     expect(commentCall[bodyIdx]).toContain("CEO approved shutdown");
+  });
+
+  it("includes token hash prefix when token provided", async () => {
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      ghCalls.push(args);
+      if (args.includes("list")) return JSON.stringify([{ number: 10 }]);
+      return "";
+    });
+
+    await logFrameworkExit("test", "my-secret-token");
+    // Find the comment call (has --body)
+    const commentCall = ghCalls.find(c => c.includes("--body"));
+    expect(commentCall).toBeDefined();
+    const bodyIdx = commentCall!.indexOf("--body") + 1;
+    const body = commentCall![bodyIdx];
+    expect(body).toContain("Token validation");
+    expect(body).not.toContain("my-secret-token");
+  });
+
+  it("logFrameworkActivation records activation event", async () => {
+    restoreGh = setGhExecutor(async (args: string[]) => {
+      ghCalls.push(args);
+      if (args.includes("list")) return JSON.stringify([{ number: 10 }]);
+      return "";
+    });
+
+    const result = await logFrameworkActivation("init-bot");
+    expect(result).toBe(true);
+
+    const commentCall = ghCalls[1];
+    const bodyIdx = commentCall.indexOf("--body") + 1;
+    expect(commentCall[bodyIdx]).toContain("framework activate");
+    expect(commentCall[bodyIdx]).toContain("init-bot");
+  });
+});
+
+describe("hashTokenPrefix / validateTokenByHash", () => {
+  it("returns consistent 8-char hex prefix", () => {
+    const hash = hashTokenPrefix("test-token");
+    expect(hash).toHaveLength(8);
+    expect(hashTokenPrefix("test-token")).toBe(hash);
+  });
+
+  it("different tokens produce different hashes", () => {
+    expect(hashTokenPrefix("token-a")).not.toBe(hashTokenPrefix("token-b"));
+  });
+
+  it("validateTokenByHash returns true for matching token", () => {
+    const hash = hashTokenPrefix("correct-token");
+    expect(validateTokenByHash("correct-token", hash)).toBe(true);
+  });
+
+  it("validateTokenByHash returns false for wrong token", () => {
+    const hash = hashTokenPrefix("correct-token");
+    expect(validateTokenByHash("wrong-token", hash)).toBe(false);
   });
 });

--- a/src/cli/lib/gate-checkrun.test.ts
+++ b/src/cli/lib/gate-checkrun.test.ts
@@ -87,4 +87,36 @@ describe("loadGateStatusFromCheckRuns", () => {
     expect(result.error).toBe("gh_error");
     expect(result.errorMessage).toContain("not authenticated");
   });
+
+  it("maps timed_out to failed", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify({ name: GATE_WORKFLOW_NAMES.A, status: "completed", conclusion: "timed_out" }),
+    );
+    const result = await loadGateStatusFromCheckRuns("x");
+    expect(result.state!.gateA.status).toBe("failed");
+  });
+
+  it("maps startup_failure to failed", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify({ name: GATE_WORKFLOW_NAMES.B, status: "completed", conclusion: "startup_failure" }),
+    );
+    const result = await loadGateStatusFromCheckRuns("x");
+    expect(result.state!.gateB.status).toBe("failed");
+  });
+
+  it("maps action_required to failed", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify({ name: GATE_WORKFLOW_NAMES.C, status: "completed", conclusion: "action_required" }),
+    );
+    const result = await loadGateStatusFromCheckRuns("x");
+    expect(result.state!.gateC.status).toBe("failed");
+  });
+
+  it("maps stale to failed", async () => {
+    restoreGh = setGhExecutor(async () =>
+      JSON.stringify({ name: GATE_WORKFLOW_NAMES.A, status: "completed", conclusion: "stale" }),
+    );
+    const result = await loadGateStatusFromCheckRuns("x");
+    expect(result.state!.gateA.status).toBe("failed");
+  });
 });

--- a/src/cli/lib/gate-model.test.ts
+++ b/src/cli/lib/gate-model.test.ts
@@ -10,7 +10,6 @@ import {
   updateGateA,
   updateGateB,
   updateGateC,
-  resetGateState,
   areAllGatesPassed,
   collectFailures,
   buildAllGatesResult,
@@ -122,21 +121,7 @@ describe("gate-model", () => {
     });
   });
 
-  describe("resetGateState", () => {
-    it("resets all gates to pending", () => {
-      const state = createGateState();
-      updateGateA(state, [makeCheck()]);
-      updateGateB(state, [makeCheck()]);
-      updateGateC(state, [makeSSOTCheck()]);
-      expect(state.gateA.status).toBe("passed");
-
-      resetGateState(state);
-      expect(state.gateA.status).toBe("pending");
-      expect(state.gateB.status).toBe("pending");
-      expect(state.gateC.status).toBe("pending");
-      expect(state.gateA.checks).toHaveLength(0);
-    });
-  });
+  // resetGateState removed (#94) — gates managed by GitHub Actions check runs
 
   describe("areAllGatesPassed", () => {
     it("returns true when all gates are passed", () => {

--- a/src/cli/lib/gate-model.ts
+++ b/src/cli/lib/gate-model.ts
@@ -161,13 +161,8 @@ export function updateGateC(
   };
 }
 
-/** @deprecated Gate reset is not applicable with check runs. See #62. */
-export function resetGateState(state: GateState): void {
-  const now = new Date().toISOString();
-  state.gateA = { status: "pending", checks: [], checkedAt: now };
-  state.gateB = { status: "pending", checks: [], checkedAt: now };
-  state.gateC = { status: "pending", checks: [], checkedAt: now };
-}
+// resetGateState() removed (#94). Gates are managed by GitHub Actions check runs.
+// To re-run gates, push a new commit or re-run workflows in GitHub Actions.
 
 export function areAllGatesPassed(state: GateState): boolean {
   return (


### PR DESCRIPTION
## Summary
- #94: #62 post-merge gap 修正 (gate reset 削除 + テスト拡充)

## Changes (5 files, +91 -28)
- B1: `resetGateState()` 関数削除 (gate-model.ts, gate.ts, gate-model.test.ts)
- B2: audit-log tests 5 → 10 (+5: token hash, activation, hash prefix validation)
- B3: gate-checkrun tests 6 → 10 (+4: timed_out/startup_failure/action_required/stale → failed)

## 完了条件
- [x] `resetGateState` が src/cli/ に 0 件 (test 除く)
- [x] audit-log tests ≥ 10 (10)
- [x] gate-checkrun tests ≥ 10 (10)
- [x] npm test: 1588 pass, regression 0
- [x] tsc clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)