### PR TITLE
docs(lead-impl-workflow): IMPL.md template skeleton (Phase 0.3, #108)

### DIFF
--- a/templates/specs/IMPL.md.template
+++ b/templates/specs/IMPL.md.template
@@ -1,5 +1,9 @@
 # {{FEATURE_NAME}} IMPL (施工図)
 
+> **Status**: frozen template asset for Sub-PR 1.4 (CLI emit wiring).
+> **Currently NOT emitted by `framework init-feature`** — current CLI generates from `templates/project/docs/*` to `docs/{spec,impl,verify,ops}` (see `src/cli/commands/init-feature.ts`).
+> **World-view note**: this template assumes `docs/specs/<feature>/IMPL.md` layout (post Sub-PR 1.4). Existing `docs/{spec,impl,verify,ops}` layout is the runtime SSOT until Sub-PR 1.4 lands.
+
 > doc4l 4-layer / IMPL layer
 > 作成: {{LEAD_BOT}}
 > 対応 SPEC: ./SPEC.md
@@ -7,7 +11,8 @@
 > 参照規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§10 必須セクション + evidence label 規約)
 
 <!--
-本 template は `framework init-feature <name>` で emit される IMPL.md 雛形です。
+本 template は将来 `framework init-feature <name>` が Sub-PR 1.4 (CLI emit wiring) 着地後に
+will be emitted by `framework init-feature` after Sub-PR 1.4 CLI wiring。
 §1〜§10 は 04b_IMPL_FORMAT.md で定義された必須セクション、
 順序および名称は SPEC.md FR-L2.1 に拘束されます (Gate 2: IMPL Presence で検証)。
 

--- a/templates/specs/IMPL.md.template
+++ b/templates/specs/IMPL.md.template
@@ -1,0 +1,175 @@
+# {{FEATURE_NAME}} IMPL (施工図)
+
+> doc4l 4-layer / IMPL layer
+> 作成: {{LEAD_BOT}}
+> 対応 SPEC: ./SPEC.md
+> 関連: VERIFY.md / OPS.md (同 directory)
+> 参照規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§12 必須セクション + evidence label 規約)
+
+<!--
+本 template は `framework init-feature <name>` で emit される IMPL.md 雛形です。
+§1〜§10 は 04b_IMPL_FORMAT.md で定義された必須セクション、
+順序および名称は SPEC.md FR-L2.1 に拘束されます (Gate 2: IMPL Presence で検証)。
+
+placeholder:
+  {{FEATURE_NAME}}  — feature 名 (snake_case 推奨)
+  {{LEAD_BOT}}      — 担当 lead-bot 名 (例: lead-ama / ARC interim)
+-->
+
+---
+
+## §1 アーキテクチャ概観
+
+<!--
+feature 全体のレイヤ構造・プロセス境界・主要 component を 1 図で示す。
+レイヤ図 (ASCII art) / プロセス境界 / Step → Step の data flow を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §1 参照。
+-->
+
+(empty — 着手時に lead-bot が記入)
+
+---
+
+## §2 モジュール構造
+
+<!--
+新規 / 変更ファイルツリーを 1 表に集約。reviewer が PR diff を読む前に全体像を掴める状態を作る。
+種別 (新規 / 既存改訂 / 削除) × パス × 変更概要の 3 列表が必須。
+レイヤ別に §2.1 / §2.2 / §2.3 等で分割可。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §2 参照。
+-->
+
+(empty)
+
+---
+
+## §3 実装順序
+
+<!--
+feature を sub-PR に分解し、依存グラフと着手順序を明示する。
+Phase 区分 / Sub-PR 番号 + 概要 + 依存関係 / 依存グラフ図 (ASCII art 可) が必須。
+1 PR 1 concern 原則。bundle 必須の場合は Gap 名 + bundle 理由を明記。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §3 参照。
+-->
+
+(empty)
+
+---
+
+## §4 コードパターン
+
+<!--
+主要 interface / class / function signature を具体的に示し、実装者の頭で再構築させない。
+TypeScript / 該当言語の signature (型まで) / 入出力の型と invariant / 既存パターンとの整合性参照を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §4 参照。
+-->
+
+(empty)
+
+---
+
+## §5 既存コードからの移行
+
+<!--
+既存 codebase への影響範囲を実コード grep で実測し、紙上設計と実装乖離を排除する。
+影響箇所の grep 結果 (件数 + 代表 path) / 後方互換戦略 / 既存 OPEN PR への影響評価を必須要素とする。
+本 §5 内の assumption は Step 3.45 (Feasibility PoC) で `framework feasibility-check` により検証され、
+[推測] ラベルが [検証済] に置換される。Gate 3 (per-FR traceability matrix) は §5 を中心に評価する。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §5 + `04c_FEASIBILITY_POC_FORMAT.md` 参照。
+-->
+
+(empty)
+
+---
+
+## §6 サブPR 5-section template
+
+<!--
+lead-bot が起票する各 sub-PR の 5-section instruction で共通する Forbidden / Test fixtures を
+IMPL.md レベルで一度宣言し、各 issue で重複記述を避ける。
+全 sub-PR 共通の Forbidden / Test fixtures / Open decisions のデフォルト境界を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §6 参照。
+-->
+
+(empty)
+
+---
+
+## §7 Adapter / 契約の詳細
+
+<!--
+feature が外部世界 (UI / LLM / DB / Auth / Platform 等) と接する箇所の adapter 契約を明示する。
+env var 切替や文字列 config による多態は abstraction leak として検出する。
+adapter interface (port pattern) / variant 一覧 / 対称性確認 / failure mode 列挙を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §7 参照。
+-->
+
+(empty)
+
+---
+
+## §8 Phase 0 ブートストラップ (該当時)
+
+<!--
+feature が新規 framework 機構を立ち上げる場合、文書化のみで先行 merge できる Phase 0 boundary を明示する。
+Phase 0 が存在する feature のみ: 文書化スコープ / code touch 禁止の宣言 / Phase 1 着手前提を必須要素とする。
+Phase 0 を持たない feature は本セクションを「該当なし」として明記する (省略禁止)。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §8 参照。
+-->
+
+(empty / 該当なし)
+
+---
+
+## §9 Open decisions
+
+<!--
+implementer (dev-bot) が自由に判断してよい項目を列挙する。本セクションに列挙されないものは暗黙凍結。
+implementer 自由項目の明示列挙 / 暗黙凍結の宣言 / escalate 宛先を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §9 参照。
+-->
+
+(empty)
+
+---
+
+## §10 lead 責任の明示
+
+<!--
+当該 IMPL.md の作成者と更新責任者を明示する。SPEC drift / IMPL stale 発覚時の問合せ先を読み手に伝える。
+作成者 / 最終更新日 / SPEC との対応 / escalate criteria を必須要素とする。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §10 参照。
+-->
+
+- 作成者: {{LEAD_BOT}}
+- 最終更新日: (Conventional commits の commit date)
+- 対応 SPEC: ./SPEC.md
+- escalate criteria: SPEC drift 検出時 → ARC / cross-cutting 影響 → CTO / per-PR judgment → codex-auditor
+
+---
+
+## Evidence label legend
+
+IMPL.md 内のすべての substantive assertion (技術判断・実数値・設計選択) には以下 3 種のラベルを付与する [文献確認: 04b_IMPL_FORMAT.md §11]。
+
+| ラベル | 英語 | 意味 | 使用条件 |
+|---|---|---|---|
+| `[検証済]` | `[observed]` | 実コード / 実環境で観測 | grep / 実行 / smoke 実施で確認した数値・挙動 |
+| `[文献確認]` | `[referenced]` | 既存 doc / spec / commit / msg を参照 | path / msg id / commit hash 併記推奨 |
+| `[推測]` | `[unverified]` / `[hypothesis]` / `[propose]` | hypothesis、未検証 | Step 3.45 (Feasibility PoC) で検証され `[検証済]` に置換される候補 |
+
+書式例:
+- `fs.readFileSync の利用箇所は 546 箇所 [検証済: ripgrep 実行 04-27]`
+- `adapter pattern を採用 [文献確認: distribution/SPEC.md FR-D2]`
+- `LLM 呼出し total cost は約 $5 [推測: 静的見積、smoke 未実施]`
+
+ラベル不在の substantive assertion は L1 lead レビューで差戻し対象。
+
+---
+
+## 関連 doc
+
+- 親 SPEC: `./SPEC.md`
+- format 規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§12 必須セクション)
+- feasibility 仕様: `docs/specs/04c_FEASIBILITY_POC_FORMAT.md` (Step 3.45 + Gate 3)
+- governance: `.claude/rules/governance-flow.md` (lead 責任「IMPL doc authoring」)

--- a/templates/specs/IMPL.md.template
+++ b/templates/specs/IMPL.md.template
@@ -4,7 +4,7 @@
 > 作成: {{LEAD_BOT}}
 > 対応 SPEC: ./SPEC.md
 > 関連: VERIFY.md / OPS.md (同 directory)
-> 参照規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§12 必須セクション + evidence label 規約)
+> 参照規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§10 必須セクション + evidence label 規約)
 
 <!--
 本 template は `framework init-feature <name>` で emit される IMPL.md 雛形です。
@@ -170,6 +170,6 @@ IMPL.md 内のすべての substantive assertion (技術判断・実数値・設
 ## 関連 doc
 
 - 親 SPEC: `./SPEC.md`
-- format 規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§12 必須セクション)
+- format 規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§10 必須セクション)
 - feasibility 仕様: `docs/specs/04c_FEASIBILITY_POC_FORMAT.md` (Step 3.45 + Gate 3)
 - governance: `.claude/rules/governance-flow.md` (lead 責任「IMPL doc authoring」)

--- a/templates/specs/IMPL.md.template
+++ b/templates/specs/IMPL.md.template
@@ -80,7 +80,7 @@ TypeScript / 該当言語の signature (型まで) / 入出力の型と invarian
 影響箇所の grep 結果 (件数 + 代表 path) / 後方互換戦略 / 既存 OPEN PR への影響評価を必須要素とする。
 本 §5 内の assumption は Step 3.45 (Feasibility PoC) で `framework feasibility-check` により検証され、
 [推測] ラベルが [検証済] に置換される。Gate 3 (per-FR traceability matrix) は §5 を中心に評価する。
-詳細は `docs/specs/04b_IMPL_FORMAT.md` §5 + `04c_FEASIBILITY_POC_FORMAT.md` 参照。
+詳細は `docs/specs/04b_IMPL_FORMAT.md` §5 参照。
 -->
 
 (empty)
@@ -176,5 +176,7 @@ IMPL.md 内のすべての substantive assertion (技術判断・実数値・設
 
 - 親 SPEC: `./SPEC.md`
 - format 規範: `docs/specs/04b_IMPL_FORMAT.md` (§1〜§10 必須セクション)
-- feasibility 仕様: `docs/specs/04c_FEASIBILITY_POC_FORMAT.md` (Step 3.45 + Gate 3)
 - governance: `.claude/rules/governance-flow.md` (lead 責任「IMPL doc authoring」)
+
+<!-- Note: feasibility 仕様 `docs/specs/04c_FEASIBILITY_POC_FORMAT.md` (Step 3.45 + Gate 3) は Sub-PR 0.4 で land 予定 (現在 not yet)。land 後に本 list へ追加する。 -->
+


### PR DESCRIPTION
## Summary

Phase 0.3 — IMPL.md skeleton template asset。§1〜§10 必須セクション + Evidence label legend を採用。**現状は frozen template asset**、CLI emit wiring (Sub-PR 1.4 / Phase 1 scope) 着地まで `framework init-feature` からは emit されない。

**Cycle 3 rebase + dead-ref 解消 (2026-05-02 09:43 JST)**: PR #110 (Sub-PR 0.1) merge 済 (squash commit `6905abf`)。本 PR を `origin/main` 上に rebase。`templates/specs/IMPL.md.template` 内の dead reference (`04c_FEASIBILITY_POC_FORMAT.md`) は §5 内 1 箇所削除 + 関連 doc list は inline コメントに格下げ (「Sub-PR 0.4 で land 予定 (現在 not yet)」)。

- **New** `templates/specs/IMPL.md.template`
  - §1〜§10 全 section header skeleton (各 section に HTML comment で説明)
  - placeholder: `{{FEATURE_NAME}}` / `{{LEAD_BOT}}`
  - Evidence label legend (3 ラベル全列挙、英語名併記)
  - 関連 doc link (SPEC / 04b_IMPL_FORMAT / governance-flow) — 04c は Sub-PR 0.4 land 後に追加
  - cycle 1: 「§1〜§12 必須セクション」表記を **「§1〜§10」** に統一 (3 箇所、親 SPEC FR-L2.1 と整合)
  - **cycle 2 (axis 5/6 解消)**: file 冒頭に frozen-asset frontmatter 追加 (Status / Currently NOT emitted / World-view note)、「emit される」→ 「will be emitted by `framework init-feature` after Sub-PR 1.4 CLI wiring」(future tense)
  - **cycle 3 (rebase + dead-ref)**: 04c reference を inline comment に格下げ、PR #110 merge 後に再起動

Refs:
- 親 SPEC: `docs/specs/lead-impl-workflow/SPEC.md` FR-L2.3
- 親 IMPL: `docs/specs/lead-impl-workflow/IMPL.md` §4.3 / §3 Phase 0.3
- ARC dispatch (msg `ffaa8090` 04-27)
- ARC cycle 1 dispatch (msg `9a665b55` 04-27、auditor axis 5 SSOT alignment finding 対応)
- ARC cycle 2 dispatch (msg `9b366b12` 04-27、auditor 🔴 BLOCK 全 axis ✅ target)
- ARC cycle 3 dispatch (msg `a1f6574c` + `14d713f7` 05-02、PR #110 merge 後 rebase + dead-ref 解消)

Closes #108

## Cycle 2 後の axis 5 評価 (overclaim 後退)

§1〜§10 統一は **SPEC FR-L2.1 整合のみ**。repo-wide SSOT (現行 CLI の世界観 drift = `templates/project/docs/*` → `docs/{spec,impl,verify,ops}` vs 本 template の `docs/specs/<feature>/IMPL.md`) は本 PR scope 外、**Sub-PR 1.4 (CLI emit wiring) で resolve** されます。本 PR は将来 contract の先置きであり、生成機能の一部を入れるものではありません。

## Merge 順序 (cycle 3 update)

cycle 0-2 では merge 順序前提を本 PR body で明示していました。cycle 3 時点で:

- ✅ **`docs/specs/04b_IMPL_FORMAT.md`** (Sub-PR 0.1、PR #110 で **merge 済** squash `6905abf`)
- ✅ **`.claude/rules/governance-flow.md`** (Sub-PR 0.1、PR #110 で **merge 済** squash `6905abf`)
- ⚠️ **`docs/specs/04c_FEASIBILITY_POC_FORMAT.md`** (Sub-PR 0.4、未起票) — template から hard reference を削除、関連 doc list には inline comment で「Sub-PR 0.4 で land 予定 (現在 not yet)」と明示

これにより本 PR 単独 merge でも dead reference は残らない (04c の inline comment は HTML コメント、emit 時には markdown 上に表示されない note)。

## §4 Test fixtures (merge gate)

- [x] **test 1**: `templates/specs/IMPL.md.template` 存在 ✅
- [x] **test 2**: §1〜§10 全 10 section header — `grep -c '^## §' templates/specs/IMPL.md.template` → **10** ✅
- [x] **test 3**: placeholder `{{FEATURE_NAME}}` 1 件以上 — **2 hit** ✅
- [x] **test 4**: Evidence label legend 3 ラベル全列挙 — 計 **8 件** ✅
- [x] **cycle 1 axis 5 (count)**: 「§1〜§12」表記 0 件 / 「§1〜§10」表記 ≥ 1 ✅ (3 件)
- [x] **cycle 1 governance path**: `~/.claude/rules` 0 件 / `.claude/rules` ≥ 1 ✅
- [x] **cycle 2 frontmatter**: `grep "Status.*frozen template asset for Sub-PR 1.4"` 1 hit ✅
- [x] **cycle 2 frontmatter**: `grep "Currently NOT emitted"` 1 hit ✅
- [x] **cycle 2 future tense**: `grep "will be emitted by"` 1 hit ✅
- [x] **cycle 3 rebase**: `git merge-base --is-ancestor 6905abf HEAD` exit 0 ✅ (PR #110 squash merge commit ancestor 含む)
- [x] **cycle 3 dead-ref**: `grep -c "04c_FEASIBILITY_POC_FORMAT" templates/specs/IMPL.md.template` → **1** (inline comment のみ) / `grep -c "Sub-PR 0.4"` → **1** ✅

## Scope (Phase 0 = 文書化のみ)

- ✅ コード touch なし (`src/` / `bin/` / `scripts/` 全て untouched)
- ✅ 現行 CLI (`src/cli/`) touch なし (世界観統一は Sub-PR 1.4)
- ✅ docs/specs/* 既存 file touch なし (Sub-PR 0.1 / 0.2 scope)
- ✅ 04c_FEASIBILITY_POC_FORMAT.md 新規作成なし (Sub-PR 0.4 scope、scope creep 禁止遵守)
- ✅ §1〜§10 構造変更なし (cycle 3 は dead-ref 削除 + inline comment 格下げのみ)

## Reviewer chain

- L1 lead: ARC interim
- L2 codex-auditor 6-axis
- L3 CTO sanity (cross-cutting governance)
- merge: CTO

## Route

`route:ceo-approval` (governance change、CEO 承認 SPEC レベルで既受領)

## Open decisions (実装者判断、§5 範囲)

- frontmatter phrasing (top-of-file note 形式採用、frontmatter YAML は不要と判断)
- HTML comment 形式での説明文付与 (initial state は empty body)
- placeholder は `{{FEATURE_NAME}}` + `{{LEAD_BOT}}` の 2 種採用
- §10 lead 責任の bullet list 形式
- Evidence label legend を独立 section として末尾配置
- **cycle 3**: 04c 参照は inline comment 格下げ (削除のみではなく、Sub-PR 0.4 land 予定の signal を温存)
- **cycle 3**: rebase commit prefix は `docs(rebase):`
