### PR TITLE
chore(bootstrap): .framework/project.json — ADF self-host Gate B unblock (#105)

### DIFF
--- a/.framework/project.json
+++ b/.framework/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "ai-dev-framework",
+  "version": "0.1.0",
+  "profileType": "cli",
+  "description": "AI Dev Framework — meta-framework for AI agent-driven development",
+  "createdAt": "2026-04-27T07:00:00.000Z",
+  "updatedAt": "2026-04-27T07:00:00.000Z",
+  "phase": -1,
+  "status": "initialized",
+  "repository": "watchout/ai-dev-framework",
+  "techStack": {
+    "framework": "nodejs-cli",
+    "language": "typescript",
+    "ui": "none",
+    "runtime": "node",
+    "package_manager": "npm",
+    "testing": "vitest",
+    "deployment": "npm-package"
+  },
+  "config": {
+    "aiProvider": "anthropic",
+    "aiModel": "claude-sonnet-4-20250514",
+    "autoCommit": false,
+    "escalationMode": "strict"
+  }
+}

--- a/src/cli/commands/cli-commands.test.ts
+++ b/src/cli/commands/cli-commands.test.ts
@@ -6,6 +6,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 const CLI_PATH = path.resolve("src/cli/index.ts");
@@ -18,7 +20,10 @@ function runCli(args: string): string {
   });
 }
 
-function runCliWithExit(args: string): {
+function runCliWithExit(
+  args: string,
+  options: { cwd?: string } = {},
+): {
   stdout: string;
   exitCode: number;
   stderr: string;
@@ -28,6 +33,7 @@ function runCliWithExit(args: string): {
       encoding: "utf-8",
       timeout: 15000,
       stdio: ["pipe", "pipe", "pipe"],
+      cwd: options.cwd,
     });
     return { stdout, exitCode: 0, stderr: "" };
   } catch (error) {
@@ -41,6 +47,19 @@ function runCliWithExit(args: string): {
       stderr: err.stderr ?? "",
       exitCode: err.status ?? 1,
     };
+  }
+}
+
+// Creates a fresh non-framework directory (no .framework/project.json) so that
+// CLI invocations exercise the "outside a framework project" code paths even
+// when the test suite runs from inside the ADF repo (which itself is now a
+// framework project after the bootstrap PR).
+function withNonFrameworkDir<T>(fn: (dir: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adf-cli-test-"));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 
@@ -143,10 +162,12 @@ describe("audit command", () => {
   });
 
   it("ssot without target exits with error about target required", () => {
-    const result = runCliWithExit("audit ssot");
-    expect(result.exitCode).not.toBe(0);
-    const combined = result.stdout + result.stderr;
-    expect(combined).toMatch(/Target|target/i);
+    withNonFrameworkDir((cwd) => {
+      const result = runCliWithExit("audit ssot", { cwd });
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Target|target/i);
+    });
   });
 });
 
@@ -196,9 +217,11 @@ describe("status command", () => {
   });
 
   it("status in a non-framework dir exits with error", () => {
-    const result = runCliWithExit("status");
-    expect(result.exitCode).not.toBe(0);
-    const combined = result.stdout + result.stderr;
-    expect(combined).toMatch(/framework|init|retrofit/i);
+    withNonFrameworkDir((cwd) => {
+      const result = runCliWithExit("status", { cwd });
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/framework|init|retrofit/i);
+    });
   });
 });

--- a/src/cli/commands/cli-commands.test.ts
+++ b/src/cli/commands/cli-commands.test.ts
@@ -10,8 +10,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const CLI_PATH = path.resolve("src/cli/index.ts");
-const TSX = "npx tsx";
+// Resolve repo-anchored paths at module load time, before any test-level cwd
+// manipulation (withNonFrameworkDir / runCliWithExit({ cwd })). Using `npx tsx`
+// or cwd-relative paths leaks the test runner's cwd into the resolution and
+// breaks under tmp dir cwd in clean/offline environments (auditor block on
+// PR #112 cycle 2: hidden impact + regression class).
+const REPO_ROOT = process.cwd();
+const CLI_PATH = path.resolve(REPO_ROOT, "src/cli/index.ts");
+const TSX = path.resolve(REPO_ROOT, "node_modules", ".bin", "tsx");
 
 function runCli(args: string): string {
   return execSync(`${TSX} ${CLI_PATH} ${args}`, {


### PR DESCRIPTION
## Summary

ADF repo 自身の bootstrap。`.framework/project.json` が無いことで全 PR の Gate B workflow が `not found` で fail していた dogfooding ギャップを解消する PR。**cycle 2: scope 表現を「environment-sensitive bootstrap」に訂正、test code 含む全 scope を honest 化。**

- **New** `.framework/project.json` (cycle 0、commit `75f85f4`)
  - `profileType: "cli"` (ADF 自身は CLI tool が主 entry)
  - shape は `src/cli/lib/templates.ts:626` の `generateProjectState` を **参考に** 作成。ただし `repository` / `description` / `runtime` / `package_manager` / `deployment` 等のフィールドは ADF 固有値で独自 fill しており、template 完全準拠ではない (axis 6 honest 修飾 by ARC msg `9a665b55`)
  - 内部固有名詞 hardcode なし、ADF core internal-agnostic 維持
- **test harness fix** `src/cli/commands/cli-commands.test.ts` (cycle 1、commit `357cb3e`)
  - `.framework/project.json` 追加で「ADF repo は non-framework dir」前提が壊れた 2 test を tmp dir setup で修正
  - `runCliWithExit` に optional `cwd` parameter 追加 / `withNonFrameworkDir<T>(fn)` helper 追加
  - **production code 不変、test code 含む全 scope は `cli-commands.test.ts` +41/-9 のみ touch** (cycle 2 honest 修飾)

## Cycle 2 honest 化 (auditor L2 verdict 🟡 CONDITIONAL → ✅)

### axis 6 (honesty) 訂正
- 旧「code 不変」→「**production code 不変、test code 含む全 scope は cli-commands.test.ts +41/-9 のみ touch**」
- 旧「pure doc-only / path-only」→「**environment-sensitive bootstrap**」(axis 4 regression class 整合)

### axis 3 (hidden impact) 明示
`.framework/` state 追加で repo root が framework project として認識される。今後の non-framework 前提 test/script は同様の tmp dir setup (cycle 1 で追加した `withNonFrameworkDir` helper) が必要。表面化していない前提依存が他の test file / 将来 script に残っている可能性がある (auditor 指摘)。

### axis 5 (SSOT 整合) follow-up commitment
**Issue #119 起票済**: `.framework/project.json` を generator/validator 起点へ migrate する follow-up を発行。`generateProjectState` を canonical source として regenerate / validate できる形に寄せ、schema drift を CI で検出可能にする。本 PR scope 外、merge 後対応。

Refs:
- 親 SPEC: `docs/specs/lead-impl-workflow/SPEC.md` (本 PR は Phase 0 第 5 sub-PR、bootstrap 単発として位置付け)
- ARC dispatch (msg `959c5421` 04-27、緊急並行 dispatch)
- §2 「local PASS」訂正の ARC judgment (msg `76cc68be` 04-27、option B 採用)
- ARC cycle 1 dispatch (msg `b2565711` test setup + msg `9a665b55` axis 6 body 訂正)
- ARC cycle 2 dispatch (msg `9b366b12` 04-27、auditor 🟡 CONDITIONAL 全 axis ✅ target)
- follow-up: #119 (.framework/project.json generator/validator migrate)

Closes #105

## §4 Test fixtures (merge gate)

- [x] **schema 妥当性**: `JSON.parse()` valid — `node -e "require('./.framework/project.json')"` PASS
- [x] **profile-model 整合**: `profileType: "cli"` は `isValidProfileType` を通過
- [x] **CI Gate B**: PASS ✅ (run `24980776377`)
- [x] **Unit Tests + Critical Gate**: cycle 0 で 2 test fail、cycle 1 で test harness 修正後 PASS ✅ (1632 / 1632)
- [x] **production code touch 0**: cycle 0 + cycle 1 通じて `src/cli/commands/` 配下の production code は不変、test file 1 件のみ touch
- [x] **他 Gate 副作用なし**: Gate A / Gate C / Lint / Type Check / Bypass / Secrets / Security / Build / CLI Smoke / detect 全 PASS
- [x] **cycle 2 axis 6**: PR body に「production code 不変、test code 含む全 scope は cli-commands.test.ts +41/-9 のみ touch」明記 ✅
- [x] **cycle 2 axis 4**: PR body に「environment-sensitive bootstrap」明記 ✅
- [x] **cycle 2 axis 5**: follow-up Issue #119 で `.framework/project.json` を generator/validator 起点へ migrate する commitment 明記 ✅

## Scope

- ✅ cycle 0: `.framework/project.json` 1 file 追加
- ✅ cycle 1: `cli-commands.test.ts` test harness 修正 (test setup のみ、production code 不変)
- ✅ cycle 2: PR body のみ訂正 (commit 追加なし、text-only)
- ✅ `.github/workflows/gate-b.yml` は touch せず (workflow 緩和で逃げる anti-pattern を回避、project.json で正面突破)
- ✅ 内部固有名詞 hardcode なし

## Local CLI 観測 (参考、本 PR scope 外)

`npx tsx src/cli/index.ts gate check-b` をローカル実行すると `.framework/plan.json` 不在で fail する。これは local CLI が plan.json 直接 check、CI workflow は GH Issues `feature` label fallback する乖離による。**ARC judgment (msg `76cc68be`) で本 PR scope 外として確定** — Phase 1 で別 follow-up として対応予定。本 PR の merge gate は CI Gate B PASS のみ。

## Reviewer chain

- L1 lead: ARC interim
- L2 codex-auditor 6-axis
- L3 CTO sanity (cross-cutting なし)
- merge: CTO

## Route

`route:fast-merge` (environment-sensitive bootstrap、production code 不変、test harness + 設定ファイル)

## Open decisions (実装者判断、§5 範囲)

- `description`: "AI Dev Framework — meta-framework for AI agent-driven development"
- `createdAt` / `updatedAt`: `2026-04-27T07:00:00.000Z`
- `version`: `"0.1.0"`、`phase`: `-1`、`status`: `"initialized"`
- `techStack`: `nodejs-cli` / `typescript` / `none` / `vitest` / `npm-package`
- `config`: `generateProjectState` default 踏襲
- cycle 1 tmp dir 生成: `fs.mkdtempSync(...)` + `try/finally` cleanup
- cycle 1 chdir vs explicit cwd option: explicit `runCliWithExit({ cwd })` (parallel test race 回避)
- cycle 2 follow-up Issue 番号: **#119** (本 PR cycle 2 起票)
- branch 名: `chore/bootstrap-project-json`

## Post-merge 確認 (Definition of Done)

- [ ] 本 PR merge 後、PR #110 / #111 の Gate B 再 run = PASS 確認
- [ ] 必要に応じて他 OPEN PR (#104 / #91 等) の Gate B 再 trigger
- [ ] follow-up Issue #119 の triage / 着手判断