### PR TITLE
feat(phase1): add impl-validator (Sub-PR 1.1, lead-impl-workflow Phase 1)

### DIFF
--- a/src/cli/lib/impl-validator.test.ts
+++ b/src/cli/lib/impl-validator.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for impl-validator (Sub-PR 1.1 of lead-impl-workflow Phase 1).
+ *
+ * Covers:
+ * - All 10 required sections present + evidence labels → PASS
+ * - §1〜§7 + §9〜§10 (§8 absent, optional) → PASS
+ * - §1 missing → WARNING
+ * - Evidence label count == 0 → BLOCK
+ * - Evidence label 3 種 ([検証済] / [文献確認] / [推測]) → count == 3
+ * - Self-dogfood: parent IMPL `lead-impl-workflow/IMPL.md` returns PASS or WARNING
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  validateImpl,
+  EVIDENCE_LABEL_RE,
+  REQUIRED_SECTIONS,
+} from "./impl-validator.js";
+
+function withTempImpl<T>(content: string, fn: (filePath: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adf-impl-validator-"));
+  const filePath = path.join(dir, "IMPL.md");
+  try {
+    fs.writeFileSync(filePath, content, "utf-8");
+    return fn(filePath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const ALL_SECTIONS = `## §1 アーキテクチャ概観
+content [検証済: smoke run]
+
+## §2 モジュール構造
+content
+
+## §3 実装順序
+content
+
+## §4 コードパターン
+content
+
+## §5 既存コードからの移行
+content
+
+## §6 サブPR
+content
+
+## §7 契約
+content
+
+## §8 Phase 0 bootstrap
+content
+
+## §9 Open decisions
+content
+
+## §10 lead 責任
+content
+`;
+
+describe("impl-validator", () => {
+  it("returns PASS when all 10 sections + at least one evidence label are present", () => {
+    withTempImpl(ALL_SECTIONS, (file) => {
+      const result = validateImpl(file);
+      expect(result.status).toBe("PASS");
+      expect(result.missingSections).toEqual([]);
+      expect(result.evidenceLabelCount).toBeGreaterThanOrEqual(1);
+      expect(result.errors).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  it("returns PASS when §8 (optional) is absent but §1〜§7, §9, §10 + evidence are present", () => {
+    const without8 = ALL_SECTIONS.replace(/## §8 Phase 0 bootstrap\ncontent\n\n/, "");
+    withTempImpl(without8, (file) => {
+      const result = validateImpl(file);
+      expect(result.status).toBe("PASS");
+      expect(result.missingSections).toEqual([]);
+    });
+  });
+
+  it("returns WARNING when §1 is missing but evidence label exists", () => {
+    const without1 = ALL_SECTIONS.replace(/## §1 アーキテクチャ概観\ncontent \[検証済: smoke run\]\n\n/, "");
+    // Re-introduce evidence label elsewhere so status is WARNING (missing section), not BLOCK (no evidence).
+    const content = without1.replace("## §2 モジュール構造\ncontent", "## §2 モジュール構造\ncontent [検証済]");
+    withTempImpl(content, (file) => {
+      const result = validateImpl(file);
+      expect(result.status).toBe("WARNING");
+      expect(result.missingSections).toContain("§1 アーキテクチャ概観");
+      expect(result.warnings.some((w) => w.type === "missing_section")).toBe(true);
+    });
+  });
+
+  it("returns BLOCK when no evidence label is present", () => {
+    const noEvidence = ALL_SECTIONS.replace(" [検証済: smoke run]", "");
+    withTempImpl(noEvidence, (file) => {
+      const result = validateImpl(file);
+      expect(result.status).toBe("BLOCK");
+      expect(result.evidenceLabelCount).toBe(0);
+      expect(result.errors.some((e) => e.type === "no_evidence_label")).toBe(true);
+    });
+  });
+
+  it("counts all 3 evidence label variants ([検証済] / [文献確認] / [推測])", () => {
+    const triLabel = `${ALL_SECTIONS}
+extra [文献確認: parent SPEC FR-L2]
+extra [推測: not yet observed]
+`;
+    withTempImpl(triLabel, (file) => {
+      const result = validateImpl(file);
+      expect(result.evidenceLabelCount).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("REQUIRED_SECTIONS exposes 10 entries with §8 marked optional", () => {
+    expect(REQUIRED_SECTIONS).toHaveLength(10);
+    const eight = REQUIRED_SECTIONS.find((s) => s.label === "§8 Phase 0");
+    expect(eight?.optional).toBe(true);
+  });
+
+  it("EVIDENCE_LABEL_RE matches all 3 Japanese label variants", () => {
+    const sample = "[検証済] [文献確認] [推測]";
+    const matches = sample.match(EVIDENCE_LABEL_RE) ?? [];
+    expect(matches).toHaveLength(3);
+  });
+
+  // Self-dogfood: validate the parent IMPL.md that authorizes this very PR.
+  it("self-dogfood: parent lead-impl-workflow/IMPL.md returns PASS or WARNING (never BLOCK)", () => {
+    const parentImpl = path.resolve(
+      process.cwd(),
+      "docs/specs/lead-impl-workflow/IMPL.md",
+    );
+    if (!fs.existsSync(parentImpl)) {
+      // Skip when not running inside the ADF repo (e.g. consumer environments).
+      return;
+    }
+    const result = validateImpl(parentImpl);
+    expect(["PASS", "WARNING"]).toContain(result.status);
+    expect(result.evidenceLabelCount).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/lib/impl-validator.test.ts
+++ b/src/cli/lib/impl-validator.test.ts
@@ -73,9 +73,21 @@ describe("impl-validator", () => {
     });
   });
 
-  it("returns PASS when §8 (optional) is absent but §1〜§7, §9, §10 + evidence are present", () => {
+  it("returns WARNING when §8 header is absent (cycle 2: §8 header always required per ARC ruling)", () => {
     const without8 = ALL_SECTIONS.replace(/## §8 Phase 0 bootstrap\ncontent\n\n/, "");
     withTempImpl(without8, (file) => {
+      const result = validateImpl(file);
+      expect(result.status).toBe("WARNING");
+      expect(result.missingSections).toContain("§8 Phase 0");
+    });
+  });
+
+  it("returns PASS when §8 header is present with body '該当なし' (cycle 2: header required, body free)", () => {
+    const naBody = ALL_SECTIONS.replace(
+      "## §8 Phase 0 bootstrap\ncontent",
+      "## §8 Phase 0 bootstrap\n\n該当なし",
+    );
+    withTempImpl(naBody, (file) => {
       const result = validateImpl(file);
       expect(result.status).toBe("PASS");
       expect(result.missingSections).toEqual([]);
@@ -115,10 +127,10 @@ extra [推測: not yet observed]
     });
   });
 
-  it("REQUIRED_SECTIONS exposes 10 entries with §8 marked optional", () => {
+  it("REQUIRED_SECTIONS exposes 10 entries, all required (cycle 2: §8 always required)", () => {
     expect(REQUIRED_SECTIONS).toHaveLength(10);
     const eight = REQUIRED_SECTIONS.find((s) => s.label === "§8 Phase 0");
-    expect(eight?.optional).toBe(true);
+    expect(eight).toBeDefined();
   });
 
   it("EVIDENCE_LABEL_RE matches all 3 Japanese label variants", () => {

--- a/src/cli/lib/impl-validator.ts
+++ b/src/cli/lib/impl-validator.ts
@@ -1,0 +1,118 @@
+/**
+ * IMPL.md validator — deterministic checks for the per-feature 施工図 IMPL.md
+ * authored by lead-bot in Step 3.4 (Lead IMPL Authoring).
+ *
+ * Part of ADF v1.2.0 lead-impl-workflow Sub-PR 1.1
+ * (parent SPEC `docs/specs/lead-impl-workflow/SPEC.md` FR-L2.1 / FR-L4,
+ * parent IMPL `docs/specs/lead-impl-workflow/IMPL.md` §4.1).
+ *
+ * Checks (all deterministic, NO LLM):
+ * 1. Required sections §1〜§10 exist (§8 Phase 0 bootstrap is optional)
+ * 2. Evidence label (`[検証済]` / `[文献確認]` / `[推測]`) appears at least once
+ *
+ * Status semantics:
+ * - `evidenceCount === 0`            → BLOCK   (FR-L2.2 violation)
+ * - `missing.length > 0` (excl. §8)  → WARNING (FR-L4.3, L1 lead may upgrade to BLOCK)
+ * - else                              → PASS
+ *
+ * Principle #0: No LLM calls in this module.
+ */
+import * as fs from "node:fs";
+
+// ─────────────────────────────────────────────
+// Constants — literal from parent IMPL.md §4.1
+// ─────────────────────────────────────────────
+
+/**
+ * Required IMPL.md section header patterns (line-anchored, multiline).
+ * §8 (Phase 0 bootstrap) is optional and excluded from missingSections when absent.
+ */
+export const REQUIRED_SECTIONS: { re: RegExp; label: string; optional?: boolean }[] = [
+  { re: /^## §1 アーキテクチャ概観/m, label: "§1 アーキテクチャ概観" },
+  { re: /^## §2 モジュール構造/m, label: "§2 モジュール構造" },
+  { re: /^## §3 実装順序/m, label: "§3 実装順序" },
+  { re: /^## §4 コードパターン/m, label: "§4 コードパターン" },
+  { re: /^## §5 既存コードからの移行/m, label: "§5 既存コードからの移行" },
+  { re: /^## §6 サブPR/m, label: "§6 サブPR" },
+  { re: /^## §7 .*契約/m, label: "§7 契約" },
+  { re: /^## §8 Phase 0/m, label: "§8 Phase 0", optional: true },
+  { re: /^## §9 Open decisions/m, label: "§9 Open decisions" },
+  { re: /^## §10 lead 責任/m, label: "§10 lead 責任" },
+];
+
+/**
+ * Evidence label regex — matches the 3 canonical labels in either Japanese
+ * or English form, optionally followed by inline qualifier text.
+ */
+export const EVIDENCE_LABEL_RE =
+  /\[(?:検証済 observed|文献確認 referenced|推測 unverified|検証済|文献確認|推測|observed|referenced|unverified|hypothesis|propose)[^\]]*\]/g;
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+export interface ImplValidationResult {
+  status: "PASS" | "WARNING" | "BLOCK";
+  missingSections: string[];
+  evidenceLabelCount: number;
+  errors: ImplFinding[];
+  warnings: ImplFinding[];
+}
+
+export interface ImplFinding {
+  type: "missing_section" | "no_evidence_label" | "empty_section" | "format";
+  message: string;
+  line?: number;
+}
+
+// ─────────────────────────────────────────────
+// Validator
+// ─────────────────────────────────────────────
+
+/**
+ * Validate an IMPL.md file at the given absolute path.
+ *
+ * Throws ENOENT if the file does not exist (caller is responsible for catching).
+ * Parse-level surprises (e.g. unexpected encoding) are degraded to WARNING
+ * rather than thrown — see §2 of the dispatch.
+ */
+export function validateImpl(path: string): ImplValidationResult {
+  const content = fs.readFileSync(path, "utf-8");
+
+  const missing: string[] = [];
+  for (const section of REQUIRED_SECTIONS) {
+    if (section.optional) continue;
+    if (!section.re.test(content)) {
+      missing.push(section.label);
+    }
+  }
+
+  const evidenceCount = (content.match(EVIDENCE_LABEL_RE) ?? []).length;
+
+  const errors: ImplFinding[] =
+    evidenceCount === 0
+      ? [
+          {
+            type: "no_evidence_label",
+            message:
+              "evidence label が 0 件 (FR-L2.2 違反、[検証済] / [文献確認] / [推測] のいずれかが必要)",
+          },
+        ]
+      : [];
+
+  const warnings: ImplFinding[] = missing.map((label) => ({
+    type: "missing_section",
+    message: `必須セクション欠落: ${label}`,
+  }));
+
+  const status: ImplValidationResult["status"] =
+    evidenceCount === 0 ? "BLOCK" : missing.length > 0 ? "WARNING" : "PASS";
+
+  return {
+    status,
+    missingSections: missing,
+    evidenceLabelCount: evidenceCount,
+    errors,
+    warnings,
+  };
+}

--- a/src/cli/lib/impl-validator.ts
+++ b/src/cli/lib/impl-validator.ts
@@ -25,9 +25,12 @@ import * as fs from "node:fs";
 
 /**
  * Required IMPL.md section header patterns (line-anchored, multiline).
- * §8 (Phase 0 bootstrap) is optional and excluded from missingSections when absent.
+ *
+ * ARC 裁定 (cycle 2): §8 (Phase 0 bootstrap) HEADER は always required。
+ * BODY content は Phase 0 該当時のみ実体記述 (該当しない feature は「該当なし」明記)。
+ * Body content の judgment は本 lib scope 外 (Sub-PR 1.7+)。本 lib は HEADER 存在のみ check。
  */
-export const REQUIRED_SECTIONS: { re: RegExp; label: string; optional?: boolean }[] = [
+export const REQUIRED_SECTIONS: { re: RegExp; label: string }[] = [
   { re: /^## §1 アーキテクチャ概観/m, label: "§1 アーキテクチャ概観" },
   { re: /^## §2 モジュール構造/m, label: "§2 モジュール構造" },
   { re: /^## §3 実装順序/m, label: "§3 実装順序" },
@@ -35,7 +38,7 @@ export const REQUIRED_SECTIONS: { re: RegExp; label: string; optional?: boolean 
   { re: /^## §5 既存コードからの移行/m, label: "§5 既存コードからの移行" },
   { re: /^## §6 サブPR/m, label: "§6 サブPR" },
   { re: /^## §7 .*契約/m, label: "§7 契約" },
-  { re: /^## §8 Phase 0/m, label: "§8 Phase 0", optional: true },
+  { re: /^## §8 Phase 0/m, label: "§8 Phase 0" },
   { re: /^## §9 Open decisions/m, label: "§9 Open decisions" },
   { re: /^## §10 lead 責任/m, label: "§10 lead 責任" },
 ];
@@ -81,7 +84,6 @@ export function validateImpl(path: string): ImplValidationResult {
 
   const missing: string[] = [];
   for (const section of REQUIRED_SECTIONS) {
-    if (section.optional) continue;
     if (!section.re.test(content)) {
       missing.push(section.label);
     }


### PR DESCRIPTION
## 1. Interface contract (frozen)
- Sub-PR 1.1 of `lead-impl-workflow` Phase 1 (parent SPEC FR-L2.1 / FR-L4)
- New export: `validateImpl(path: string): ImplValidationResult` from `src/cli/lib/impl-validator.ts`
- Type export: `ImplValidationResult` / `ImplFinding`
- pre: path = absolute IMPL.md file path、存在前提
- post: 同期 return (`fs.readFileSync`)、副作用なし
- error: file 不在 → `ENOENT` throw (caller catch)
- route: `route:fast-merge` (内部 lib 追加 + test、CI green 維持)

## 2. Required behavior (frozen, cycle 2 修正版)
- (a) parent IMPL.md §4.1 を **ベース**として `REQUIRED_SECTIONS` 10 個 + `EVIDENCE_LABEL_RE` を実装。**§4.1 literal そのまま採用ではなく**、ARC 裁定で §8 header always-required 化 + bare Japanese evidence label alias を拡張
- (b) status logic:
  - `evidenceCount === 0` → **BLOCK** (FR-L2.2 違反)
  - `missing.length > 0` → **WARNING** (FR-L4.3、§8 含む全 entry が対象、L1 lead が BLOCK 化可)
  - else → **PASS**
- (c) **§8 header always-required** (cycle 2 ARC 裁定):
  - 親 SPEC FR-L2.1 #8 (`lead-impl-workflow/SPEC.md:93`): 「Phase 0 ブートストラップ (該当時)」 → 該当時のみ内容必要
  - 04b §8 (`docs/specs/04b_IMPL_FORMAT.md:130`): 「§8 header 自体は省略禁止、body は『該当なし』可」
  - **= §8 HEADER は省略禁止 (always required)、BODY content は Phase 0 該当時のみ実体記述**
  - 本 lib は **HEADER 存在のみ check**。body content judgment (実体 or 「該当なし」) は本 sub-PR scope 外 (Sub-PR 1.7+)
- (d) test 9 cases (cycle 2 で 8 → 9):
  - 全 10 sections + evidence → PASS
  - **§8 absent → WARNING** (cycle 2 修正、旧 PASS から)
  - **§8 header 存在 + body 「該当なし」 → PASS** (cycle 2 新規追加)
  - §1 missing → WARNING
  - evidence 0 → BLOCK
  - 3 ラベル全種 count=3
  - REQUIRED_SECTIONS shape sanity (length 10、§8 entry 存在)
  - EVIDENCE_LABEL_RE 3 種 match
  - self-dogfood: parent `lead-impl-workflow/IMPL.md` → PASS or WARNING
- (e) `EVIDENCE_LABEL_RE`: §4.1 literal の英語 alias (`observed` / `referenced` / `unverified` / `hypothesis` / `propose`) + **bare Japanese 拡張** (`検証済` / `文献確認` / `推測` で英単語サフィックスなし)。body 内で書式例 `[検証済: smoke run]` のような bare 形式を許容するための拡張

## 3. Forbidden behavior (frozen)
- ❌ `gate-spec-validator.ts` 改変 — diff 0 ✅
- ❌ `src/cli/commands/*` touch — diff 0 ✅
- ❌ `.github/workflows/` 改変 — diff 0 ✅
- ❌ `framework init-feature` 改変 — diff 0 ✅
- ❌ feasibility-engine 混入 — Sub-PR 1.5+ scope ✅
- ❌ overclaim 文言 — cycle 2 で「literal-as-spec claim」claim 削除済 ✅
- ❌ silent fallback / try-catch swallow — `ENOENT` throw、deterministic 原則 ✅
- ❌ 04b / VERIFY.md 改変 — diff 0 ✅ (cycle 2 ARC 裁定で drift 不在を確認、両者既に整合)
- ❌ §8 body content judgment logic 追加 — Sub-PR 1.7+ scope ✅

## 4. Test fixtures (frozen, cycle 2 merge gate)
- (T1) `grep -c "optional:.*true" src/cli/lib/impl-validator.ts` → **0** ✅ (§8 optional flag 削除確認)
- (T2) `grep -c "§8" src/cli/lib/impl-validator.test.ts` → **10** ≥ 2 ✅ (両 case: missing → WARNING、present + 該当なし → PASS)
- (T3) `npx vitest run src/cli/lib/impl-validator.test.ts` → **9 tests pass** ≥ 7 ✅
- (T4) `npx tsc --noEmit` → 0 error ✅
- (T5) `gh pr checks 122` → 13/13 SUCCESS (CI run pending)
- (T6) PR body grep `litera`+`l 採用` → **0** ✅ (overclaim 削除確認)
- (T7) PR body grep `§8 header always-required\|§4.1 ベース` → ≥1 ✅ (cycle 2 honest framing 確認)

## 5. Open decisions (cycle 2 採択)
- §8 PASS case 文言: `## §8 Phase 0 bootstrap\n\n該当なし` (header literal + 1 行 body)
- PR body cycle 2 note section: 5-section 全体を cycle 2 修正版で rewrite (本 body)、旧 cycle 1 「literal-as-spec claim」claim を削除して「§4.1 ベース + ARC 裁定で §8 header always-required + bare Japanese alias 拡張」と honest 化
- commit prefix: `fix(cycle2):` (instruction 推奨)
- 04b/VERIFY drift check: ARC 裁定で「両者既に整合 (header 必須 + body 該当時のみ実体)」確認済、本 PR で改変なし

## Cycle 2 note (ARC 裁定経緯、honest)

cycle 1 (commit `acffc27`) は §4.1 を「literal-as-spec claim」として §8 を `optional: true` flag 付きで実装、§8 absent を PASS 扱いしていた。

auditor cycle 1 verdict (msg `2b9e3e3f` + `0bd1a2f6`) で axes 1/5/6 BLOCK 指摘:
- axis 1 (intent): 「literal-as-spec claim」claim と実装の差分 (§8 optional は §4.1 codeブロック内の `// optional` コメント由来だが、parent SPEC + 04b と整合解釈すると header 必須)
- axis 5 (SSOT alignment): §8 規範 conflict (parent SPEC FR-L2.1 #8 「該当時」 vs 04b §8 「header 省略禁止」)
- axis 6 (honesty): 上記 conflict を「literal-as-spec claim」と claim していた

ARC 裁定 (msg `ec8055b3`+`c8307277`、cycle 2 dispatch):
- §8 = (a-1) header always required、body は「該当なし」可
- 根拠: 親 SPEC FR-L2.1 #8 + 04b §8:130 の整合解釈

cycle 2 (commit `f3357dc`) で:
- `REQUIRED_SECTIONS` から §8 `optional: true` flag 削除、shape を `{re, label}` に簡略化
- `validateImpl` の optional skip logic 削除 (全 entry が missing 判定対象)
- test 「§8 absent → PASS」を「§8 absent → WARNING」に修正
- test 「§8 header 存在 + body 『該当なし』 → PASS」case 追加 (cycle 2 新規、9 個目)
- test `REQUIRED_SECTIONS shape sanity` を「optional flag check」から「all 10 required」に更新
- PR body cycle 2 note section で訂正経緯 honest 化、「literal-as-spec claim」claim 削除

## Refs
- 親 SPEC: `docs/specs/lead-impl-workflow/SPEC.md` FR-L2.1 / FR-L4
- 親 IMPL: `docs/specs/lead-impl-workflow/IMPL.md` §4.1 (ベース、§8 規範は parent SPEC + 04b で整合解釈)
- 04b: `docs/specs/04b_IMPL_FORMAT.md` §8:130 (header 省略禁止、body 「該当なし」可)
- 既存類似 lib: `src/cli/lib/gate-spec-validator.ts` (PR #104、structure 参考)
- ARC dispatch cycle 1: msg `dee7952d` + `abcfa610`
- ARC dispatch cycle 2: msg `ec8055b3` + `c8307277` (§8 裁定)
- auditor cycle 1 BLOCK: msg `2b9e3e3f` + `0bd1a2f6` (axes 1+5+6)

## Phase 1 plan (本 PR は Sub-PR 1.1 のみ scope)
- Sub-PR 1.2: `framework gate validate impl` CLI コマンド (本 lib を呼ぶ)
- Sub-PR 1.3: `framework gate impl` subcommand 統合
- Sub-PR 1.4: `framework init-feature` で IMPL.md.template emit
- Sub-PR 1.7+: §8 body content judgment ("該当なし" vs 実体) logic
- Sub-PR 1.5+: feasibility-engine (FR-L6 系、別 scope)
